### PR TITLE
Fix confirm modal being unreachable on short viewports

### DIFF
--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/html/index.html
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/html/index.html
@@ -60,7 +60,7 @@
         .loading { color: var(--muted); font-size: 13px; padding: 12px; text-align: center; }
         .modal-overlay { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.7); z-index: 1000; align-items: center; justify-content: center; }
         .modal-overlay.visible { display: flex; }
-        .modal { background: var(--card); border-radius: 12px; padding: 24px; width: 720px; max-width: 90vw; max-height: 80vh; display: flex; flex-direction: column; }
+        .modal { background: var(--card); border-radius: 12px; padding: 24px; width: 720px; max-width: 90vw; max-height: 80vh; display: flex; flex-direction: column; overflow-y: auto; }
         .modal-title { color: #fff; font-size: 18px; font-weight: 600; margin-bottom: 16px; }
         .modal-message { color: var(--text); margin-bottom: 20px; }
         .modal-status { color: var(--muted); font-size: 12px; margin-bottom: 12px; }


### PR DESCRIPTION
## Summary
- `.modal` had `max-height: 80vh` with no overflow handling, and sits inside a `position: fixed` overlay that doesn't scroll the page
- On short screens, a long `confirm:` message plus `inputs:` fields (e.g. Panda Breath's enable flow) could push the input fields and Confirm button past the modal's box, making them unreachable and preventing typing
- Adds `overflow-y: auto` to `.modal` so it scrolls internally instead

## Screenshot

<img width="1231" height="853" alt="image" src="https://github.com/user-attachments/assets/d819ac06-31e2-4f19-aa3d-2cb555c2516c" />
