### PR TITLE
fix(spoollink): re-resolve when the display fields are cleared

### DIFF
--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
@@ -56,6 +56,9 @@ class SpoolLink:
         self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
 
         self._channel_uids: Dict[int, str] = {}
+        self._resolved_uid: Dict[int, str] = {}
+        self._refill_tries: Dict[int, int] = {}
+        self._ptc_vendors: list = []
         self._toolhead_extruder: str = "extruder"
         self._ptc_spool_ids: List[int] = []
         self._active_spool_id: Optional[int] = None
@@ -80,7 +83,8 @@ class SpoolLink:
         logging.info("[spoollink] Klippy ready, subscribing to objects")
         status = await self.klippy_apis.subscribe_objects({
             "filament_detect": None,
-            "print_task_config": ["filament_spool_id"],
+            "print_task_config": ["filament_spool_id",
+                                  "filament_vendor", "filament_type"],
             "toolhead": ["extruder"],
         }, self._handle_status_update, {})
         self._handle_status_update(status, 0.)
@@ -88,6 +92,9 @@ class SpoolLink:
     def _handle_klippy_disconnect(self) -> None:
         logging.info("[spoollink] Klippy disconnected")
         self._channel_uids = {}
+        self._resolved_uid = {}
+        self._refill_tries = {}
+        self._ptc_vendors = []
         self._ptc_spool_ids = []
         self._active_spool_id = None
 
@@ -119,6 +126,13 @@ class SpoolLink:
                              self._ptc_spool_ids, new_ids)
                 self._ptc_spool_ids = new_ids
                 self._fire(self._sync_active_spool())
+            # A load operation makes the printer re-read the NFC tag. The tag only
+            # carries a UID, so the firmware writes empty vendor/material fields and
+            # overwrites what we resolved from Spoolman. Detect that and re-resolve.
+            vendors = ptc.get("filament_vendor")
+            if vendors is not None:
+                self._ptc_vendors = list(vendors)
+                self._check_cleared_fields()
 
         fd = status.get("filament_detect")
         if fd is None:
@@ -126,6 +140,26 @@ class SpoolLink:
         info_list = fd.get("info", [])
         for ch, info in enumerate(info_list):
             self._handle_filament_detect_channel(ch, info)
+
+    def _check_cleared_fields(self) -> None:
+        # Vendor gone while the same card is still in the feeder -> re-resolve.
+        # Capped at three attempts per card: without the cap an unresolvable
+        # spool would retry forever.
+        for ch, uid in list(self._channel_uids.items()):
+            if not uid or self._resolved_uid.get(ch) != uid:
+                continue
+            vendor = (self._ptc_vendors[ch]
+                      if ch < len(self._ptc_vendors) else None)
+            if vendor in (None, "", "NONE", "None"):
+                tries = self._refill_tries.get(ch, 0)
+                if tries < 3:
+                    self._refill_tries[ch] = tries + 1
+                    logging.info("[spoollink] ch%d: display fields cleared "
+                                 "(card %s still present) - re-resolving (%d/3)",
+                                 ch, uid, tries + 1)
+                    self._fire(self._resolve_spool(ch, card_uid=uid))
+            else:
+                self._refill_tries.pop(ch, None)
 
     def _handle_filament_detect_channel(self, ch: int, info: Any) -> None:
         if not isinstance(info, dict):
@@ -136,6 +170,7 @@ class SpoolLink:
         if uid_hex and uid_hex != prev:
             logging.info("[spoollink] ch%d: card UID changed to %s, resolving",
                          ch, uid_hex)
+            self._refill_tries.pop(ch, None)
             self._fire(self._resolve_spool(ch, card_uid=uid_hex))
 
     # -- Active spool sync --------------------------------------------------
@@ -495,6 +530,8 @@ class SpoolLink:
         reply = await self._spoollink_set(channel, message, info=info)
         if reply is not None:
             logging.info("[spoollink] ch%d: spool %s applied", channel, spool_id)
+            self._resolved_uid[channel] = uid_hex
+            self._refill_tries.pop(channel, None)
 
 
 def load_component(config: ConfigHelper) -> SpoolLink:


### PR DESCRIPTION
### What this fixes

After a load operation the spool assignment was lost on every toolhead with an NFC tag in its feeder — the display showed no material again, and the link to the Spoolman entry was gone, so consumption tracking stopped working.

### Cause

Per the [external RFID contract](https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/blob/develop/docs/design/filament_detect.md#external-rfid-support), re-reading a tag that carries only a UID is a *"tag present, no data"* update: the filament fields reset and SpoolLink is expected to resolve them again.

It doesn't, because `_handle_filament_detect_channel()` only resolves on a card UID **change**:

```python
if uid_hex and uid_hex != prev:
    self._fire(self._resolve_spool(ch, card_uid=uid_hex))
```

After a load the card is unchanged — only vendor and material fall back to empty. The condition never fires, so the resolved data stays lost.

### Change

SpoolLink now additionally subscribes to `filament_vendor` / `filament_type`, remembers the UID it last resolved successfully per channel, and re-resolves when those fields are cleared while the same card is still present.

**Capped at three attempts per card.** Without a cap, a spool that cannot be resolved would retry forever.

### Testing

Snapmaker U1, firmware `v1.5.2-paxx12-21`, four toolheads (three direct feeders with NFC readers, fourth fed by an Anycubic ACE 2 Pro), Spoolman-compatible backend.

Two consecutive load operations, one self-heal logged:

```
16:43:55  toolhead extruder changed: extruder → extruder1     ← load, head 1
16:51:15  toolhead extruder changed: extruder → extruder1     ← load, head 2
16:51:19  ch1: display fields cleared (card 049C93AD7D2681 still present) - re-resolving (1/3)
16:51:19  ch1: spool 2 applied                                ← restored, same second
```

Final state, all four toolheads intact:

```
spool_ids: [3, 2, 1, 6]
vendor   : ['Overture', 'eSun', 'Nobufil', 'Generic']
type     : ['PLA', 'PLA', 'PETG', 'PLA']
```

Running on the machine since, no errors or warnings in the Klipper or Moonraker logs.

### Note

An earlier revision of this PR also changed `06-add-spool-id-support.patch` to retain the spool id when no `SPOOL_ID` is supplied. That has been **dropped** after the discussion in #617 — it would have broken the manual-override workflow, and the reset is documented behaviour rather than a bug. This PR now only closes the gap on the SpoolLink side.

One open question from that discussion: between the reset and the re-resolve there is a window of roughly 4 seconds where `filament_spool_id` is `0`. Fine for a load between prints; for a filament change mid-print it may be worth a closer look. Happy to measure that on real hardware.

This PR targets `main`; let me know if `develop` is preferred and I'll rebase.
