### PR TITLE
Move `SET_SPOOL_ID` from `afc.cfg` to `spoollink.cfg`

### DIFF
--- a/docs/spoolman.md
+++ b/docs/spoolman.md
@@ -78,9 +78,9 @@ Hardware and setup details for both readers are in
 
 ### `SET_SPOOL_ID`
 
-Assign a Spoolman spool to an AFC lane. Reads the lane's RFID card UID,
-binds it to the spool (so a later scan resolves automatically), and
-applies the filament metadata to the channel:
+Assign a Spoolman spool to an extruder channel. Reads the channel's RFID
+card UID, binds it to the spool (so a later scan resolves automatically),
+and applies the filament metadata to the channel:
 
 ```
 SET_SPOOL_ID LANE=E0 SPOOL_ID=5
@@ -88,8 +88,12 @@ SET_SPOOL_ID LANE=E0 SPOOL_ID=5
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `LANE` | — | AFC lane name (e.g. `E0`) |
+| `LANE` | — | Lane name (e.g. `E0`); resolved through [AFC-Lite](afc-lite.md) when enabled, otherwise from the name itself |
+| `CHANNEL` | — | Extruder channel index (`0`-`3`), used instead of `LANE` |
 | `SPOOL_ID` | `0` | Spoolman spool ID; `0` clears the assignment |
+
+The macro is provided by the Spoolman integration itself, so it is
+available whenever Spoolman is enabled, with or without AFC-Lite.
 
 ## Known Conflicts
 

--- a/overlays/firmware-extended/31-feature-afc-lite/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
+++ b/overlays/firmware-extended/31-feature-afc-lite/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
@@ -75,26 +75,6 @@ gcode:
     SET_PRINT_EXTRUDER_MAP CONFIG_EXTRUDER='{new_logical}' MAP_EXTRUDER='{index}'
     SET_PRINT_EXTRUDER_MAP CONFIG_EXTRUDER='{current_logical}' MAP_EXTRUDER='{old_channel}'
 
-[gcode_macro SET_SPOOL_ID]
-gcode:
-    {% set lane     = params.LANE %}
-    {% set channel  = printer['AFC_lane ' + lane].lane %}
-    {% set spool_id = params.SPOOL_ID|default(0)|int %}
-    {% if spool_id == 0 %}
-        SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER={channel} FILAMENT_SPOOL_ID=0 FORCE=1
-    {% else %}
-        {% set uid_raw = printer.filament_detect.info[channel].CARD_UID %}
-        {% if uid_raw is iterable and uid_raw is not string %}
-            {% set ns = namespace(uid='') %}
-            {% for b in uid_raw %}{% set ns.uid = ns.uid ~ ('%02X' % b) %}{% endfor %}
-            {% set card_uid = ns.uid %}
-        {% else %}
-            {% set card_uid = '' %}
-        {% endif %}
-        { action_call_remote_method("spoollink_resolve_spool",
-            channel=channel, spool_id=spool_id, card_uid=card_uid) }
-    {% endif %}
-
 [gcode_macro CHANGE_TOOL]
 description: Change tool/lane with automatic load/unload
 gcode:

--- a/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
+++ b/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
@@ -3,3 +3,36 @@
 # Symlinked into the extended Klipper config by klipper.d/10-spoollink.sh
 # when `[spoolman] host` is set in extended2.cfg.
 [spoollink]
+
+# Assign a Spoolman spool to an extruder channel, binding the currently
+# scanned RFID card UID to it so a later scan resolves automatically.
+#
+# The channel is taken from `CHANNEL` when given, otherwise from the AFC lane
+# named by `LANE` when AFC-Lite is enabled, and finally from the lane name
+# itself (`E0` -> 0) so the macro also works without AFC-Lite.
+[gcode_macro SET_SPOOL_ID]
+description: Assign a Spoolman spool to an extruder channel
+gcode:
+    {% set lane     = params.LANE|default('') %}
+    {% if params.CHANNEL is defined %}
+        {% set channel = params.CHANNEL|int %}
+    {% elif 'AFC_lane ' + lane in printer %}
+        {% set channel = printer['AFC_lane ' + lane].lane %}
+    {% else %}
+        { action_raise_error("SET_SPOOL_ID: unknown LANE '" ~ lane ~ "', pass CHANNEL=<index> instead") }
+    {% endif %}
+    {% set spool_id = params.SPOOL_ID|default(0)|int %}
+    {% if spool_id == 0 %}
+        SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER={channel} FILAMENT_SPOOL_ID=0 FORCE=1
+    {% else %}
+        {% set uid_raw = printer.filament_detect.info[channel].CARD_UID %}
+        {% if uid_raw is iterable and uid_raw is not string %}
+            {% set ns = namespace(uid='') %}
+            {% for b in uid_raw %}{% set ns.uid = ns.uid ~ ('%02X' % b) %}{% endfor %}
+            {% set card_uid = ns.uid %}
+        {% else %}
+            {% set card_uid = '' %}
+        {% endif %}
+        { action_call_remote_method("spoollink_resolve_spool",
+            channel=channel, spool_id=spool_id, card_uid=card_uid) }
+    {% endif %}


### PR DESCRIPTION
`SET_SPOOL_ID` is part of the Spoolman integration, but it lived in the AFC-Lite tweak `afc.cfg`, so it only existed when AFC-Lite was enabled. The filament UI calls it with `LANE=E<channel>` for any channel, and the macro is useless without SpoolLink's `spoollink_resolve_spool` remote method.

This moves the macro next to `[spoollink]` in `/usr/local/share/spoollink/klipper.cfg`. That file is symlinked into the extended Klipper config only when `[spoolman] host` is set, so `SET_SPOOL_ID` now appears exactly when Spoolman is enabled, with or without AFC-Lite. Keeping it in both places was not an option — that would be a duplicate `gcode_macro` section whenever both features are on.

Channel resolution is generalised accordingly:

1. `CHANNEL=<n>` when given,
2. otherwise the `AFC_lane` object when AFC-Lite is loaded,
3. otherwise the index derived from the lane name (`E0` -> 0),
4. otherwise `action_raise_error` — an unrecognised lane no longer silently resolves to channel 0.

The clear path (`SPOOL_ID=0`) and the RFID-UID -> `spoollink_resolve_spool` call are unchanged.