### PR TITLE
Filament Manager: create Spoolman spools from RFID tags

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+* text=auto eol=lf
+
+# Windows-native command files retain their required line endings.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Firmware and packaged assets are binary.
+*.a binary
+*.bin binary
+*.bmp binary
+*.dtb binary
+*.gz binary
+*.img binary
+*.o binary
+*.so binary
+*.whl binary
+*.xz binary
+*.zip binary
+
+# Preserve two legacy upstream files that are already stored with CRLF.
+overlays/mods/afc/02-patch-moonraker/patches/home/lava/moonraker/02-metadata-thumbnail-fix.patch -text
+overlays/mods/afc/docs/canbus.md -text

--- a/.github/dev/Dockerfile
+++ b/.github/dev/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update -y && \
       build-essential \
       cmake \
       pkg-config \
+      python3 \
       squashfs-tools \
       git-core \
       bc \

--- a/.github/dev/Dockerfile
+++ b/.github/dev/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update -y && \
       build-essential \
       cmake \
       pkg-config \
+      python3 \
       squashfs-tools \
       git-core \
       bc \

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -24,8 +24,8 @@ jobs:
         python3 -m unittest scripts.test_check_line_endings
         python3 scripts/check_line_endings.py
 
-    - name: Test Filament Manager Spoolman helpers
-      run: node --test overlays/firmware-extended/68-app-filament-ui/test/spoolman-utils.test.js
+    - name: Test Filament Manager
+      run: node --test overlays/firmware-extended/68-app-filament-ui/test/*.test.js
 
   custom-firmware-build:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,6 +19,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Test firmware line-ending guard
+      run: |
+        python3 -m unittest scripts.test_check_line_endings
+        python3 scripts/check_line_endings.py
+
     - name: Test Filament Manager Spoolman helpers
       run: node --test overlays/firmware-extended/68-app-filament-ui/test/spoolman-utils.test.js
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,6 +11,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  filament-ui-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Test Filament Manager Spoolman helpers
+      run: node --test overlays/firmware-extended/68-app-filament-ui/test/spoolman-utils.test.js
+
   custom-firmware-build:
     runs-on: ubuntu-24.04-arm
     permissions:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -22,8 +22,8 @@ jobs:
         python3 -m unittest scripts.test_check_line_endings
         python3 scripts/check_line_endings.py
 
-    - name: Test Filament Manager Spoolman helpers
-      run: node --test overlays/firmware-extended/68-app-filament-ui/test/spoolman-utils.test.js
+    - name: Test Filament Manager
+      run: node --test overlays/firmware-extended/68-app-filament-ui/test/*.test.js
 
   custom-firmware-build:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,6 +17,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Test firmware line-ending guard
+      run: |
+        python3 -m unittest scripts.test_check_line_endings
+        python3 scripts/check_line_endings.py
+
     - name: Test Filament Manager Spoolman helpers
       run: node --test overlays/firmware-extended/68-app-filament-ui/test/spoolman-utils.test.js
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,6 +9,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  filament-ui-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Test Filament Manager Spoolman helpers
+      run: node --test overlays/firmware-extended/68-app-filament-ui/test/spoolman-utils.test.js
+
   custom-firmware-build:
     runs-on: ubuntu-24.04-arm
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,11 @@ FIRMWARES := $(patsubst overlays/firmware-%,%,$(wildcard overlays/firmware-*))
 MOD_LIST := $(patsubst overlays/mods/%/,%,$(wildcard overlays/mods/*/))
 INVALID_MOD_NAMES := $(filter-out $(MOD_LIST),$(MOD_NAMES))
 
-$(OUTPUT_FILE): firmware/$(FIRMWARE_FILE) tools
+.PHONY: check-line-endings
+check-line-endings:
+	python3 scripts/check_line_endings.py
+
+$(OUTPUT_FILE): firmware/$(FIRMWARE_FILE) tools | check-line-endings
 ifeq (,$(PROFILE))
 	@echo "Please specify a firmware using 'make PROFILE=<firmware>[-<mod>]*'. Available firmwares are: $(FIRMWARES). Available mods are: $(MOD_LIST)."
 	@exit 1
@@ -34,7 +38,7 @@ endif
 	./scripts/create_firmware.sh $< $(BUILD_DIR) $@ $(OVERLAYS)
 
 .PHONY: build
-build: $(OUTPUT_FILE)
+build: check-line-endings $(OUTPUT_FILE)
 
 EXTRACT_DIR := tmp/extracted-$(FIRMWARE_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,11 @@ FIRMWARES := $(patsubst overlays/firmware-%,%,$(wildcard overlays/firmware-*))
 MOD_LIST := $(patsubst overlays/mods/%/,%,$(wildcard overlays/mods/*/))
 INVALID_MOD_NAMES := $(filter-out $(MOD_LIST),$(MOD_NAMES))
 
-$(OUTPUT_FILE): firmware/$(FIRMWARE_FILE) tools
+.PHONY: check-line-endings
+check-line-endings:
+	python3 scripts/check_line_endings.py
+
+$(OUTPUT_FILE): firmware/$(FIRMWARE_FILE) tools | check-line-endings
 ifeq (,$(PROFILE))
 	@echo "Please specify a firmware using 'make PROFILE=<firmware>[-<mod>]*'. Available firmwares are: $(FIRMWARES). Available mods are: $(MOD_LIST)."
 	@exit 1
@@ -38,7 +42,7 @@ endif
 	./scripts/create_firmware.sh $< $(BUILD_DIR) $@ $(OVERLAYS)
 
 .PHONY: build
-build: $(OUTPUT_FILE)
+build: check-line-endings $(OUTPUT_FILE)
 
 EXTRACT_DIR := tmp/extracted-$(FIRMWARE_VERSION)
 

--- a/docs/spoolman.md
+++ b/docs/spoolman.md
@@ -22,6 +22,60 @@ Enable via Fluidd/Mainsail settings under
 **Snapmaker Components > Spoolman Integration**, set the Spoolman host,
 and reboot. Set the same toggle to **Disabled** to turn it off.
 
+## Creating a Spool from a U1 Channel
+
+The U1 Filament Manager can create and assign a Spoolman spool directly from
+a metadata-bearing RFID tag:
+
+1. Open **Filament Manager** and select **Read spool tags**.
+2. On a channel whose detected UID is not already stored in Spoolman, select
+   **Create Spool**.
+3. Review the filament and mass values, then select **Create and Assign**.
+
+The button is shown only when the tag provides a valid UID, vendor, material,
+and six-digit colour. UID-only, empty, and malformed tags cannot provide enough
+metadata to create a spool. They can still be assigned to an existing spool by
+using **Spool**.
+
+Before writing anything, the dialog reloads the Spoolman spool, vendor, and
+filament records. It reuses a vendor case-insensitively. It also reuses an exact
+filament match based on vendor, material, variant, and colour; blank and
+`Basic` variants are treated as equivalent. If multiple exact filament matches
+exist, the user must select one. Otherwise the dialog creates the required
+vendor and filament before creating the spool.
+
+The initial and remaining filament values use the tag's reported net mass when
+it is valid, or a reviewed default of 1000 g. When an existing filament is
+reused, its empty-spool mass is inherited. For a new filament, empty-spool mass
+is optional. Diameter, density, temperatures, colour, name, and both mass
+values remain reviewable in the dialog.
+
+Creation stores only the SpoolLink fields documented below: `card_uids` on the
+spool and, when present, `variant` on a newly created filament. If a request
+fails after one or more records were created, those records are retained and
+their IDs are reported. Retrying is safe because the dialog rechecks UID
+ownership and exact filament matches before creating additional records.
+
+## Two RFID Tags on One Spool
+
+Use **Spool** on the channel reading the second physical tag, then select the
+same Spoolman spool. SpoolLink appends the UID to that spool's comma-separated
+`card_uids` value. The picker displays the number of stored RFID tags and uses
+the following safeguards:
+
+- Adding the first UID needs no additional confirmation beyond selecting the
+  spool.
+- Adding a second UID requires an explicit **Add Second RFID** confirmation.
+- Adding a third or later UID requires an explicit warning confirmation.
+- Moving a UID from another spool requires an explicit move confirmation.
+- A UID found on more than one spool is rejected until the duplicate ownership
+  is corrected in Spoolman.
+
+After `SET_SPOOL_ID`, the Filament Manager reloads Spoolman and verifies that
+the UID has exactly one owner and that all UIDs previously stored on the target
+spool remain present. Filament metadata alone is never used to pair two tags;
+identical spools can legitimately have the same metadata.
+
 ## Apps
 
 Community apps that support SpoolLink, so scanning a tag resolves its spool
@@ -111,6 +165,9 @@ SET_SPOOL_ID LANE=E0 SPOOL_ID=5
 ## Limitations
 
 - Spoolman must be reachable from the printer over HTTP.
+- Creation and RFID assignment require Spoolman's current v1 API through
+  Moonraker's version-2 Spoolman proxy response.
+- UID ownership checks use the same 1000-spool candidate limit as SpoolLink.
 - Variant defaults to `Basic` for Snapmaker-branded filaments when not
   set in Spoolman; empty for all other vendors.
 

--- a/docs/spoolman.md
+++ b/docs/spoolman.md
@@ -58,10 +58,10 @@ ownership and exact filament matches before creating additional records.
 
 ## Two RFID Tags on One Spool
 
-Use **Spool** on the channel reading the second physical tag, then select the
-same Spoolman spool. SpoolLink appends the UID to that spool's comma-separated
-`card_uids` value. The picker displays the number of stored RFID tags and uses
-the following safeguards:
+When a channel is already assigned to a Spoolman spool and reads its unowned
+second physical tag, select **Add RFID**. For an unassigned channel, use
+**Spool** and select the intended spool. SpoolLink appends the UID to that
+spool's comma-separated `card_uids` value. The following safeguards apply:
 
 - Adding the first UID needs no additional confirmation beyond selecting the
   spool.

--- a/docs/spoolman.md
+++ b/docs/spoolman.md
@@ -34,6 +34,60 @@ Enable in the [firmware-config](firmware_config.md) web interface under
 URL including scheme and port (e.g. `http://192.168.1.100:7912`). Set the same
 toggle to **Disabled** to turn it off.
 
+## Creating a Spool from a U1 Channel
+
+The U1 Filament Manager can create and assign a Spoolman spool directly from
+a metadata-bearing RFID tag:
+
+1. Open **Filament Manager** and select **Read spool tags**.
+2. On a channel whose detected UID is not already stored in Spoolman, select
+   **Create Spool**.
+3. Review the filament and mass values, then select **Create and Assign**.
+
+The button is shown only when the tag provides a valid UID, vendor, material,
+and six-digit colour. UID-only, empty, and malformed tags cannot provide enough
+metadata to create a spool. They can still be assigned to an existing spool by
+using **Spool**.
+
+Before writing anything, the dialog reloads the Spoolman spool, vendor, and
+filament records. It reuses a vendor case-insensitively. It also reuses an exact
+filament match based on vendor, material, variant, and colour; blank and
+`Basic` variants are treated as equivalent. If multiple exact filament matches
+exist, the user must select one. Otherwise the dialog creates the required
+vendor and filament before creating the spool.
+
+The initial and remaining filament values use the tag's reported net mass when
+it is valid, or a reviewed default of 1000 g. When an existing filament is
+reused, its empty-spool mass is inherited. For a new filament, empty-spool mass
+is optional. Diameter, density, temperatures, colour, name, and both mass
+values remain reviewable in the dialog.
+
+Creation stores only the SpoolLink fields documented below: `card_uids` on the
+spool and, when present, `variant` on a newly created filament. If a request
+fails after one or more records were created, those records are retained and
+their IDs are reported. Retrying is safe because the dialog rechecks UID
+ownership and exact filament matches before creating additional records.
+
+## Two RFID Tags on One Spool
+
+Use **Spool** on the channel reading the second physical tag, then select the
+same Spoolman spool. SpoolLink appends the UID to that spool's comma-separated
+`card_uids` value. The picker displays the number of stored RFID tags and uses
+the following safeguards:
+
+- Adding the first UID needs no additional confirmation beyond selecting the
+  spool.
+- Adding a second UID requires an explicit **Add Second RFID** confirmation.
+- Adding a third or later UID requires an explicit warning confirmation.
+- Moving a UID from another spool requires an explicit move confirmation.
+- A UID found on more than one spool is rejected until the duplicate ownership
+  is corrected in Spoolman.
+
+After `SET_SPOOL_ID`, the Filament Manager reloads Spoolman and verifies that
+the UID has exactly one owner and that all UIDs previously stored on the target
+spool remain present. Filament metadata alone is never used to pair two tags;
+identical spools can legitimately have the same metadata.
+
 ## Apps
 
 Community apps that support SpoolLink, so scanning a tag resolves its spool
@@ -127,6 +181,9 @@ available whenever Spoolman is enabled, with or without AFC-Lite.
 ## Limitations
 
 - Spoolman must be reachable from the printer over HTTP.
+- Creation and RFID assignment require Spoolman's current v1 API through
+  Moonraker's version-2 Spoolman proxy response.
+- UID ownership checks use the same 1000-spool candidate limit as SpoolLink.
 - Variant defaults to `Basic` for Snapmaker-branded filaments when not
   set in Spoolman; empty for all other vendors.
 

--- a/docs/spoolman.md
+++ b/docs/spoolman.md
@@ -70,10 +70,10 @@ ownership and exact filament matches before creating additional records.
 
 ## Two RFID Tags on One Spool
 
-Use **Spool** on the channel reading the second physical tag, then select the
-same Spoolman spool. SpoolLink appends the UID to that spool's comma-separated
-`card_uids` value. The picker displays the number of stored RFID tags and uses
-the following safeguards:
+When a channel is already assigned to a Spoolman spool and reads its unowned
+second physical tag, select **Add RFID**. For an unassigned channel, use
+**Spool** and select the intended spool. SpoolLink appends the UID to that
+spool's comma-separated `card_uids` value. The following safeguards apply:
 
 - Adding the first UID needs no additional confirmation beyond selecting the
   spool.

--- a/overlays/firmware-extended/68-app-filament-ui/root/etc/nginx/fluidd.d/filament.conf
+++ b/overlays/firmware-extended/68-app-filament-ui/root/etc/nginx/fluidd.d/filament.conf
@@ -5,4 +5,5 @@ location = /filament {
 location /filament/ {
     alias /usr/local/filament-ui/html/;
     index index.html;
+    add_header Cache-Control "no-store, no-cache, must-revalidate" always;
 }

--- a/overlays/firmware-extended/68-app-filament-ui/root/etc/nginx/fluidd.d/filament.conf
+++ b/overlays/firmware-extended/68-app-filament-ui/root/etc/nginx/fluidd.d/filament.conf
@@ -9,4 +9,5 @@ location = /filament {
 location /filament/ {
     alias /usr/local/filament-ui/html/;
     index index.html;
+    add_header Cache-Control "no-store, no-cache, must-revalidate" always;
 }

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/index.html
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Filament Manager</title>
-<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="style.css?v=2">
 </head>
 <body>
 <header>
@@ -202,7 +202,7 @@
     </div>
 </div>
 
-<script src="spoolman-utils.js"></script>
-<script src="script.js"></script>
+<script src="spoolman-utils.js?v=2"></script>
+<script src="script.js?v=2"></script>
 </body>
 </html>

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/index.html
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/index.html
@@ -106,6 +106,103 @@
     </div>
 </div>
 
+<!-- Create Spoolman Spool Modal -->
+<div id="create-spool-modal" class="tag-edit-overlay" style="display:none">
+    <div class="tag-edit-dialog create-spool-dialog" role="dialog" aria-modal="true" aria-labelledby="create-spool-title">
+        <div class="tag-edit-header">
+            <h2 class="tag-edit-title" id="create-spool-title">Create Spoolman Spool</h2>
+            <button class="tag-edit-close" id="create-spool-close" type="button" aria-label="Close">&times;</button>
+        </div>
+        <div class="tag-edit-body">
+            <form id="create-spool-form">
+                <div class="create-spool-source" aria-label="RFID source">
+                    <div><span>Extruder</span><strong id="create-spool-channel">-</strong></div>
+                    <div><span>Card UID</span><strong id="create-spool-uid">-</strong></div>
+                </div>
+
+                <div id="create-spool-notice" class="create-spool-notice" style="display:none"></div>
+
+                <div id="create-spool-match-section" class="field-block" style="display:none">
+                    <label class="form-label">Matching Spoolman filament
+                        <select id="create-spool-filament" name="filament_id"></select>
+                    </label>
+                    <p class="form-help" id="create-spool-match-help"></p>
+                </div>
+
+                <div id="create-spool-filament-fields">
+                    <div class="form-row">
+                        <label class="form-label">Vendor *
+                            <input type="text" name="vendor" required autocomplete="off">
+                        </label>
+                        <label class="form-label">Material *
+                            <input type="text" name="material" required autocomplete="off">
+                        </label>
+                        <label class="form-label">Variant
+                            <input type="text" name="variant" autocomplete="off">
+                        </label>
+                    </div>
+                    <div class="form-row">
+                        <label class="form-label">Filament name *
+                            <input type="text" name="name" required autocomplete="off">
+                        </label>
+                        <label class="form-label">Colour (RRGGBB) *
+                            <input type="text" name="color" required maxlength="7" spellcheck="false" autocomplete="off">
+                        </label>
+                    </div>
+                    <div class="form-row">
+                        <label class="form-label">Diameter (mm) *
+                            <input type="number" name="diameter" required min="0.1" max="5" step="0.01">
+                        </label>
+                        <label class="form-label">Density (g/cm&sup3;) *
+                            <input type="number" name="density" required min="0.5" max="3" step="0.01">
+                        </label>
+                        <label class="form-label">Nozzle temperature (&deg;C)
+                            <input type="number" name="nozzle_temp" min="1" max="500" step="1">
+                        </label>
+                        <label class="form-label">Bed temperature (&deg;C)
+                            <input type="number" name="bed_temp" min="1" max="200" step="1">
+                        </label>
+                    </div>
+                </div>
+
+                <div class="create-spool-section-title">Spool mass</div>
+                <div class="form-row">
+                    <label class="form-label">Initial net filament (g) *
+                        <input type="number" name="net_weight" required min="1" step="1">
+                    </label>
+                    <label class="form-label">Empty spool / tare (g)
+                        <input type="number" name="tare_weight" min="0" step="1" placeholder="Optional">
+                    </label>
+                </div>
+                <p class="form-help">Initial and remaining filament are set to the same reviewed net mass. Tare is optional.</p>
+
+                <div class="modal-actions">
+                    <button type="button" id="create-spool-cancel" class="modal-btn-cancel">Cancel</button>
+                    <button type="submit" id="create-spool-submit" class="modal-btn-submit">Create and Assign</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- RFID assignment confirmation modal -->
+<div id="rfid-confirm-modal" class="tag-edit-overlay" style="display:none">
+    <div class="tag-edit-dialog confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="rfid-confirm-title">
+        <div class="tag-edit-header">
+            <h2 class="tag-edit-title" id="rfid-confirm-title">Confirm RFID Assignment</h2>
+            <button class="tag-edit-close" id="rfid-confirm-close" type="button" aria-label="Close">&times;</button>
+        </div>
+        <div class="tag-edit-body">
+            <div id="rfid-confirm-content" class="confirm-content"></div>
+            <div class="modal-actions">
+                <button type="button" id="rfid-confirm-cancel" class="modal-btn-cancel">Cancel</button>
+                <button type="button" id="rfid-confirm-accept" class="modal-btn-submit">Confirm</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="spoolman-utils.js"></script>
 <script src="script.js"></script>
 </body>
 </html>

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/index.html
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/index.html
@@ -110,6 +110,103 @@
     </div>
 </div>
 
+<!-- Create Spoolman Spool Modal -->
+<div id="create-spool-modal" class="tag-edit-overlay" style="display:none">
+    <div class="tag-edit-dialog create-spool-dialog" role="dialog" aria-modal="true" aria-labelledby="create-spool-title">
+        <div class="tag-edit-header">
+            <h2 class="tag-edit-title" id="create-spool-title">Create Spoolman Spool</h2>
+            <button class="tag-edit-close" id="create-spool-close" type="button" aria-label="Close">&times;</button>
+        </div>
+        <div class="tag-edit-body">
+            <form id="create-spool-form">
+                <div class="create-spool-source" aria-label="RFID source">
+                    <div><span>Extruder</span><strong id="create-spool-channel">-</strong></div>
+                    <div><span>Card UID</span><strong id="create-spool-uid">-</strong></div>
+                </div>
+
+                <div id="create-spool-notice" class="create-spool-notice" style="display:none"></div>
+
+                <div id="create-spool-match-section" class="field-block" style="display:none">
+                    <label class="form-label">Matching Spoolman filament
+                        <select id="create-spool-filament" name="filament_id"></select>
+                    </label>
+                    <p class="form-help" id="create-spool-match-help"></p>
+                </div>
+
+                <div id="create-spool-filament-fields">
+                    <div class="form-row">
+                        <label class="form-label">Vendor *
+                            <input type="text" name="vendor" required autocomplete="off">
+                        </label>
+                        <label class="form-label">Material *
+                            <input type="text" name="material" required autocomplete="off">
+                        </label>
+                        <label class="form-label">Variant
+                            <input type="text" name="variant" autocomplete="off">
+                        </label>
+                    </div>
+                    <div class="form-row">
+                        <label class="form-label">Filament name *
+                            <input type="text" name="name" required autocomplete="off">
+                        </label>
+                        <label class="form-label">Colour (RRGGBB) *
+                            <input type="text" name="color" required maxlength="7" spellcheck="false" autocomplete="off">
+                        </label>
+                    </div>
+                    <div class="form-row">
+                        <label class="form-label">Diameter (mm) *
+                            <input type="number" name="diameter" required min="0.1" max="5" step="0.01">
+                        </label>
+                        <label class="form-label">Density (g/cm&sup3;) *
+                            <input type="number" name="density" required min="0.5" max="3" step="0.01">
+                        </label>
+                        <label class="form-label">Nozzle temperature (&deg;C)
+                            <input type="number" name="nozzle_temp" min="1" max="500" step="1">
+                        </label>
+                        <label class="form-label">Bed temperature (&deg;C)
+                            <input type="number" name="bed_temp" min="1" max="200" step="1">
+                        </label>
+                    </div>
+                </div>
+
+                <div class="create-spool-section-title">Spool mass</div>
+                <div class="form-row">
+                    <label class="form-label">Initial net filament (g) *
+                        <input type="number" name="net_weight" required min="1" step="1">
+                    </label>
+                    <label class="form-label">Empty spool / tare (g)
+                        <input type="number" name="tare_weight" min="0" step="1" placeholder="Optional">
+                    </label>
+                </div>
+                <p class="form-help">Initial and remaining filament are set to the same reviewed net mass. Tare is optional.</p>
+
+                <div class="modal-actions">
+                    <button type="button" id="create-spool-cancel" class="modal-btn-cancel">Cancel</button>
+                    <button type="submit" id="create-spool-submit" class="modal-btn-submit">Create and Assign</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- RFID assignment confirmation modal -->
+<div id="rfid-confirm-modal" class="tag-edit-overlay" style="display:none">
+    <div class="tag-edit-dialog confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="rfid-confirm-title">
+        <div class="tag-edit-header">
+            <h2 class="tag-edit-title" id="rfid-confirm-title">Confirm RFID Assignment</h2>
+            <button class="tag-edit-close" id="rfid-confirm-close" type="button" aria-label="Close">&times;</button>
+        </div>
+        <div class="tag-edit-body">
+            <div id="rfid-confirm-content" class="confirm-content"></div>
+            <div class="modal-actions">
+                <button type="button" id="rfid-confirm-cancel" class="modal-btn-cancel">Cancel</button>
+                <button type="button" id="rfid-confirm-accept" class="modal-btn-submit">Confirm</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="spoolman-utils.js"></script>
 <script src="script.js"></script>
 </body>
 </html>

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/index.html
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/index.html
@@ -8,7 +8,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Filament Manager</title>
-<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="style.css?v=2">
 </head>
 <body>
 <header>
@@ -206,7 +206,7 @@
     </div>
 </div>
 
-<script src="spoolman-utils.js"></script>
-<script src="script.js"></script>
+<script src="spoolman-utils.js?v=2"></script>
+<script src="script.js?v=2"></script>
 </body>
 </html>

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/script.js
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/script.js
@@ -668,11 +668,19 @@ function createChannelCard(channel) {
         const owners = spoolmanInventoryLoaded
             ? SM.findUidOwners(spoolmanInventory, uid)
             : [];
-        if (!spoolmanInventoryLoaded || owners.length === 0) {
+        if (!spoolmanInventoryLoaded) {
             const createBtn = mkBtn('+ Create Spool', 'create-spool-btn', () => openCreateSpoolModal(channel.channel));
-            createBtn.disabled = !spoolmanInventoryLoaded;
-            if (createBtn.disabled) createBtn.title = 'Waiting for the Spoolman inventory';
+            createBtn.disabled = true;
+            createBtn.title = 'Waiting for the Spoolman inventory';
             actions.appendChild(createBtn);
+        } else if (owners.length === 0) {
+            const assignedSpool = spoolId != null ? spoolmanSpools.get(Number(spoolId)) : null;
+            if (assignedSpool) {
+                actions.appendChild(mkBtn('+ Add RFID', 'create-spool-btn', () =>
+                    assignSpoolToChannel(channel.channel, assignedSpool.id, false)));
+            } else {
+                actions.appendChild(mkBtn('+ Create Spool', 'create-spool-btn', () => openCreateSpoolModal(channel.channel)));
+            }
         }
     }
     if (spoolmanActive) actions.appendChild(mkBtn('⊕ Spool', '', () => openSpoolPicker(channel.channel)));
@@ -904,9 +912,13 @@ function renderSpoolList(filter) {
 }
 
 async function pickSpool(spoolId) {
-    if (spoolPickerChannel === null || spoolAssignmentBusy) return;
+    if (spoolPickerChannel === null) return;
+    await assignSpoolToChannel(spoolPickerChannel, spoolId, true);
+}
+
+async function assignSpoolToChannel(channel, spoolId, closePicker) {
+    if (spoolAssignmentBusy) return;
     spoolAssignmentBusy = true;
-    const channel = spoolPickerChannel;
     try {
         const uid = currentChannelUid(channel);
         const spools = await refreshSpoolmanInventory(false);
@@ -946,7 +958,7 @@ async function pickSpool(spoolId) {
             ensureChannelUid(channel, uid);
         }
 
-        closeModal('spoolman-modal');
+        if (closePicker) closeModal('spoolman-modal');
         showStatus('Assigning spool…', 'info');
         await executeSpoolAssignment(channel, target, uid, previousTargetUids);
         showStatus(`Spool #${spoolId} assigned to Extruder ${channel + 1}`, 'success');

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/script.js
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/script.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const SM = window.SpoolmanUtils;
+if (!SM) throw new Error('spoolman-utils.js failed to load');
+
 // Subscribe to all fields so we get state[] push updates too
 const QUERY_OBJECTS = {
     filament_detect: null,
@@ -20,12 +23,17 @@ let refreshing = false;
 let spoolmanActive = false;
 let spoolmanUrl = null;
 let spoolmanSpools = new Map();
+let spoolmanInventory = [];
+let spoolmanInventoryLoaded = false;
 let spoolPickerChannel = null;
 let spoolRefreshTimer = null;
 const SPOOL_REFRESH_ACTIVE_MS = 3000;
 const SPOOL_REFRESH_IDLE_MS = 30000;
 let spoolPickerSpools = [];
 let spoolPickerCurrentId = null;
+let spoolAssignmentBusy = false;
+let createSpoolContext = null;
+let rfidConfirmationResolve = null;
 
 // Last known full status — merged incrementally from notify_status_update
 let cachedStatus = {
@@ -149,17 +157,17 @@ function setConnectionStatus(connected) {
 
 // ── Initial data load (no gcodes — shows existing printer state) ──────────
 
-function loadSpoolmanStatus() {
-    sendRPC('server.spoolman.status').then(status => {
-        if (status.spoolman_connected) {
-            spoolmanActive = true;
-            if (!spoolRefreshTimer) scheduleSpoolRefresh();
-        }
-    }).catch(() => {});
-
-    sendRPC('server.config').then(config => {
-        spoolmanUrl = config.config?.spoolman?.server || null;
-    }).catch(() => {});
+async function loadSpoolmanStatus() {
+    const [status, config] = await Promise.all([
+        sendRPC('server.spoolman.status').catch(() => null),
+        sendRPC('server.config').catch(() => null),
+    ]);
+    spoolmanActive = !!status?.spoolman_connected;
+    spoolmanUrl = config?.config?.spoolman?.server || null;
+    if (spoolmanActive) {
+        if (!spoolRefreshTimer) scheduleSpoolRefresh();
+        await refreshSpoolmanInventory(false).catch(() => {});
+    }
 }
 
 async function loadInitialData() {
@@ -173,17 +181,73 @@ async function loadInitialData() {
     }
 }
 
+async function spoolmanRequest(requestMethod, path, options = {}) {
+    const params = {
+        request_method: requestMethod,
+        path,
+        use_v2_response: true,
+    };
+    if (options.query) params.query = options.query;
+    if (options.body !== undefined) params.body = options.body;
+
+    const result = await sendRPC('server.spoolman.proxy', params);
+    if (result?.error) {
+        const status = result.error.status_code ? ` (${result.error.status_code})` : '';
+        throw new Error(`${result.error.message || 'Spoolman request failed'}${status}`);
+    }
+    return result?.response;
+}
+
 async function fetchSpoolmanAllSpools() {
-    try {
-        const result = await sendRPC('server.spoolman.proxy', { request_method: 'GET', path: '/v1/spool' });
-        return Array.isArray(result) ? result : [];
-    } catch { return []; }
+    const result = await spoolmanRequest('GET', '/v1/spool', {
+        query: 'limit=1000&allow_archived=true',
+    });
+    if (!Array.isArray(result)) throw new Error('Spoolman returned an invalid spool list');
+    return result;
 }
 
 async function fetchSpoolmanSpool(id) {
-    try {
-        return await sendRPC('server.spoolman.proxy', { request_method: 'GET', path: `/v1/spool/${id}` });
-    } catch { return null; }
+    return await spoolmanRequest('GET', `/v1/spool/${id}`);
+}
+
+async function fetchSpoolmanVendors() {
+    const result = await spoolmanRequest('GET', '/v1/vendor', {
+        query: 'limit=1000&allow_archived=true',
+    });
+    if (!Array.isArray(result)) throw new Error('Spoolman returned an invalid vendor list');
+    return result;
+}
+
+async function fetchSpoolmanFilaments() {
+    const result = await spoolmanRequest('GET', '/v1/filament', {
+        query: 'limit=1000&allow_archived=true',
+    });
+    if (!Array.isArray(result)) throw new Error('Spoolman returned an invalid filament list');
+    return result;
+}
+
+function storeSpoolmanInventory(spools, rerender = true) {
+    spoolmanInventory = spools;
+    spoolmanInventoryLoaded = true;
+    spoolmanSpools = new Map(spools.map(spool => [Number(spool.id), spool]));
+    if (rerender) rebuildFromCache();
+}
+
+async function refreshSpoolmanInventory(rerender = true) {
+    const spools = await fetchSpoolmanAllSpools();
+    storeSpoolmanInventory(spools, rerender);
+    return spools;
+}
+
+function upsertSpoolmanSpool(spool) {
+    if (!spool) return;
+    const id = Number(spool.id);
+    spoolmanSpools.set(id, spool);
+    if (spoolmanInventoryLoaded) {
+        const index = spoolmanInventory.findIndex(item => Number(item.id) === id);
+        if (index === -1) spoolmanInventory.push(spool);
+        else spoolmanInventory[index] = spool;
+    }
 }
 
 async function refreshSpoolWeights() {
@@ -191,8 +255,9 @@ async function refreshSpoolWeights() {
     const activeIds = [...new Set(channelsData.map(ch => ch.spool_id).filter(id => id != null))];
     if (activeIds.length === 0) return;
     await Promise.all(activeIds.map(async id => {
-        const spool = await fetchSpoolmanSpool(id);
-        if (spool) spoolmanSpools.set(id, spool);
+        try {
+            upsertSpoolmanSpool(await fetchSpoolmanSpool(id));
+        } catch {}
     }));
     rebuildFromCache();
 }
@@ -239,6 +304,7 @@ async function refreshAllChannels() {
         for (let i = 0; i < 4; i++) gcodes.push(`FILAMENT_DT_CLEAR CHANNEL=${i}`);
         for (let i = 0; i < 4; i++) gcodes.push(`FILAMENT_DT_UPDATE CHANNEL=${i}`);
         await sendGcode(gcodes.join('\n'));
+        if (spoolmanActive) await refreshSpoolmanInventory(false).catch(() => {});
     } catch (err) {
         showStatus(`Refresh failed: ${err.message}`, 'error');
     } finally {
@@ -251,6 +317,7 @@ async function refreshSingleChannel(channel) {
     if (!wsReady) { showStatus('Waiting for connection…', 'info'); return; }
     try {
         await sendGcode(`FILAMENT_DT_CLEAR CHANNEL=${channel}\nFILAMENT_DT_UPDATE CHANNEL=${channel}`);
+        if (spoolmanActive) await refreshSpoolmanInventory(false).catch(() => {});
     } catch (err) {
         showStatus(`Refresh failed: ${err.message}`, 'error');
     }
@@ -307,9 +374,11 @@ function parseChannelInfo(i, fd, fdState, ptc) {
     // unless the tag actually carries filament data (a material type or vendor).
     const rfidVendor  = fd.VENDOR && fd.VENDOR !== 'NONE' ? fd.VENDOR : null;
     const rfidHasData = !!(fdMainType || rfidVendor);
+    const rawRfidSubtype = fd.SUB_TYPE && fd.SUB_TYPE !== 'NONE' ? fd.SUB_TYPE : null;
     const rfidData = hasUid ? {
         type:     fdMainType,
-        sub_type: fd.SUB_TYPE && fd.SUB_TYPE !== 'NONE' && fd.SUB_TYPE !== 'Basic' ? fd.SUB_TYPE : null,
+        sub_type: rawRfidSubtype && rawRfidSubtype !== 'Basic' ? rawRfidSubtype : null,
+        variant:  rawRfidSubtype,
         vendor:   rfidVendor,
         color:    rfidHasData && fd.RGB_1 != null ? (fd.RGB_1 & 0xFFFFFF).toString(16).padStart(6, '0').toUpperCase() : null,
         min_temp: rfidHasData ? (fd.HOTEND_MIN_TEMP || null) : null,
@@ -317,6 +386,7 @@ function parseChannelInfo(i, fd, fdState, ptc) {
         bed_temp: rfidHasData ? (fd.BED_TEMP        || null) : null,
         diameter: rfidHasData && fd.DIAMETER ? fd.DIAMETER / 100.0 : null,
         density:  rfidHasData ? (fd.DENSITY         || null) : null,
+        weight:   rfidHasData ? (fd.WEIGHT          || null) : null,
     } : null;
 
     const cmpStr = (a, b) => !!(a && b && a.toLowerCase() !== b.toLowerCase());
@@ -391,7 +461,7 @@ function createChannelCard(channel) {
 
     const displayCh = channel.channel + 1;
     const { present, filament_exists: filamentExists, official: isOfficial,
-            empty: isEmpty, malformed: isMalformed, filament, card_type, uid,
+            malformed: isMalformed, filament, card_type, uid,
             spool_id: spoolId, mismatch, ptc_sources: ptcSources } = channel;
     const hasUid = uid.length > 0;
     const hasPtcInfo = !!filament.type;
@@ -444,6 +514,8 @@ function createChannelCard(channel) {
                 }
                 if (spool.remaining_weight != null) rows.push({ label: 'Remaining', value: `${Math.round(spool.remaining_weight)} g` });
                 if (spool.filament.weight  != null) rows.push({ label: 'Total',     value: `${spool.filament.weight} g` });
+                const storedUids = SM.parseCardUids(spool);
+                rows.push({ label: 'RFID tags', value: String(storedUids.length) });
                 showPopover(b, rows);
             });
             b.addEventListener('mouseleave', hidePopover);
@@ -546,6 +618,9 @@ function createChannelCard(channel) {
             addRow('Remaining', filament.remaining_weight != null
                 ? `<span class="spool-remaining">${filament.remaining_weight} g</span>`
                 : na);
+            const activeSpool = spoolId != null ? spoolmanSpools.get(Number(spoolId)) : null;
+            const storedUidCount = activeSpool ? SM.parseCardUids(activeSpool).length : null;
+            addRow('RFID tags', storedUidCount != null ? `${storedUidCount} stored` : na);
         }
 
         if (isMalformed) {
@@ -589,6 +664,17 @@ function createChannelCard(channel) {
     actions.appendChild(mkBtn('↻ Refresh', '', () => refreshSingleChannel(channel.channel)));
     actions.appendChild(mkBtn('✎ User', '', () => openOverwriteModal(channel.channel)));
     actions.appendChild(mkBtn('Reset', '', () => resetChannel(channel.channel)));
+    if (spoolmanActive && SM.isCreateEligible(channel)) {
+        const owners = spoolmanInventoryLoaded
+            ? SM.findUidOwners(spoolmanInventory, uid)
+            : [];
+        if (!spoolmanInventoryLoaded || owners.length === 0) {
+            const createBtn = mkBtn('+ Create Spool', 'create-spool-btn', () => openCreateSpoolModal(channel.channel));
+            createBtn.disabled = !spoolmanInventoryLoaded;
+            if (createBtn.disabled) createBtn.title = 'Waiting for the Spoolman inventory';
+            actions.appendChild(createBtn);
+        }
+    }
     if (spoolmanActive) actions.appendChild(mkBtn('⊕ Spool', '', () => openSpoolPicker(channel.channel)));
 
     card.appendChild(actions);
@@ -659,6 +745,94 @@ function copyToClipboard(text) {
     });
 }
 
+function currentChannelUid(channel) {
+    const current = channelsData.find(item => item.channel === channel);
+    return SM.normalizeUid(current?.uid);
+}
+
+function formatUid(uid) {
+    const normalized = SM.normalizeUid(uid);
+    return normalized ? normalized.match(/.{2}/g).join(':') : 'none';
+}
+
+function describeSpool(spool) {
+    const name = spool?.filament?.name || spool?.filament?.material || 'Unknown filament';
+    return `Spool #${spool?.id} (${name})`;
+}
+
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function ensureChannelUid(channel, expectedUid) {
+    const actualUid = currentChannelUid(channel);
+    if (actualUid !== SM.normalizeUid(expectedUid)) {
+        throw new Error(`The RFID in Extruder ${channel + 1} changed. Read the spool tag again before continuing.`);
+    }
+}
+
+function resolveRfidConfirmation(accepted) {
+    closeModal('rfid-confirm-modal');
+    if (!rfidConfirmationResolve) return;
+    const resolve = rfidConfirmationResolve;
+    rfidConfirmationResolve = null;
+    resolve(accepted);
+}
+
+function requestRfidConfirmation(title, paragraphs, confirmLabel) {
+    if (rfidConfirmationResolve) resolveRfidConfirmation(false);
+    document.getElementById('rfid-confirm-title').textContent = title;
+    document.getElementById('rfid-confirm-accept').textContent = confirmLabel;
+    const content = document.getElementById('rfid-confirm-content');
+    content.innerHTML = '';
+    for (const paragraph of paragraphs) {
+        const element = document.createElement('p');
+        element.textContent = paragraph;
+        content.appendChild(element);
+    }
+    openModal('rfid-confirm-modal');
+    return new Promise(resolve => { rfidConfirmationResolve = resolve; });
+}
+
+async function waitForRfidAssignment(targetId, uid, previousTargetUids) {
+    let lastVerification = null;
+    let lastError = null;
+    for (let attempt = 0; attempt < 4; attempt++) {
+        if (attempt > 0) await delay(250 * (2 ** (attempt - 1)));
+        try {
+            const spools = await fetchSpoolmanAllSpools();
+            storeSpoolmanInventory(spools, false);
+            lastVerification = SM.verifyUidAssignment(spools, targetId, uid, previousTargetUids);
+            if (lastVerification.ok) {
+                rebuildFromCache();
+                return lastVerification;
+            }
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    rebuildFromCache();
+    if (lastError && !lastVerification) throw lastError;
+    const owners = lastVerification?.ownerIds?.length
+        ? lastVerification.ownerIds.map(id => `#${id}`).join(', ')
+        : 'none';
+    const missing = lastVerification?.missingPrevious?.length
+        ? ` Previous target UID(s) missing: ${lastVerification.missingPrevious.join(', ')}.`
+        : '';
+    throw new Error(`RFID assignment could not be verified (current owner(s): ${owners}).${missing}`);
+}
+
+async function executeSpoolAssignment(channel, targetSpool, uid, previousTargetUids) {
+    ensureChannelUid(channel, uid);
+    await sendGcode(`SET_SPOOL_ID LANE=E${channel} CHANNEL=${channel} SPOOL_ID=${targetSpool.id}`);
+    if (uid) {
+        await waitForRfidAssignment(targetSpool.id, uid, previousTargetUids);
+    } else {
+        upsertSpoolmanSpool(await fetchSpoolmanSpool(targetSpool.id));
+        rebuildFromCache();
+    }
+}
+
 async function openSpoolPicker(channel) {
     spoolPickerChannel = channel;
     document.getElementById('spoolman-modal-title').textContent = `Pick Spool — Extruder ${channel + 1}`;
@@ -667,18 +841,22 @@ async function openSpoolPicker(channel) {
     list.innerHTML = '<div class="spoolman-loading"><span class="spinner"></span> Loading…</div>';
     openModal('spoolman-modal');
 
-    const spools = await fetchSpoolmanAllSpools();
-    spoolPickerSpools = spools;
-    const ch = channelsData.find(c => c.channel === channel);
-    spoolPickerCurrentId = ch ? ch.spool_id : null;
-    renderSpoolList('');
+    try {
+        const spools = await refreshSpoolmanInventory(false);
+        spoolPickerSpools = spools;
+        const ch = channelsData.find(c => c.channel === channel);
+        spoolPickerCurrentId = ch ? ch.spool_id : null;
+        renderSpoolList('');
+    } catch (err) {
+        list.innerHTML = `<div class="spoolman-empty">${escHtml(`Failed to load Spoolman: ${err.message}`)}</div>`;
+    }
 }
 
 function renderSpoolList(filter) {
     const list = document.getElementById('spoolman-list');
     const lower = filter.toLowerCase();
     const filtered = spoolPickerSpools.filter(s => {
-        if (s.is_archived) return false;
+        if (s.archived || s.is_archived) return false;
         if (!lower) return true;
         const name    = (s.filament.name     || '').toLowerCase();
         const material= (s.filament.material || '').toLowerCase();
@@ -708,6 +886,7 @@ function renderSpoolList(filter) {
         const swatchesHtml = swatchColors
             .map(c => `<div class="spoolman-swatch" style="background:#${escHtml(c)}"></div>`)
             .join('');
+        const rfidCount = SM.parseCardUids(s).length;
         item.innerHTML =
             `<div class="spoolman-swatches">${swatchesHtml}</div>` +
             `<div class="spoolman-info">` +
@@ -717,6 +896,7 @@ function renderSpoolList(filter) {
             `<div class="spoolman-right">` +
                 `<div class="spoolman-weight">${escHtml(weight)}</div>` +
                 `<div class="spoolman-id">#${s.id}</div>` +
+                `<div class="spoolman-rfid-count">${rfidCount} RFID tag${rfidCount === 1 ? '' : 's'}</div>` +
             `</div>`;
         item.addEventListener('click', () => pickSpool(s.id));
         list.appendChild(item);
@@ -724,17 +904,56 @@ function renderSpoolList(filter) {
 }
 
 async function pickSpool(spoolId) {
-    if (spoolPickerChannel === null) return;
+    if (spoolPickerChannel === null || spoolAssignmentBusy) return;
+    spoolAssignmentBusy = true;
     const channel = spoolPickerChannel;
-    closeModal('spoolman-modal');
     try {
+        const uid = currentChannelUid(channel);
+        const spools = await refreshSpoolmanInventory(false);
+        ensureChannelUid(channel, uid);
+        const target = spools.find(spool => Number(spool.id) === Number(spoolId));
+        if (!target) throw new Error(`Spool #${spoolId} no longer exists`);
+
+        const owners = uid ? SM.findUidOwners(spools, uid) : [];
+        if (owners.length > 1) {
+            throw new Error(`RFID ${formatUid(uid)} is already stored on multiple spools (${owners.map(owner => `#${owner.id}`).join(', ')}). Resolve the duplicate in Spoolman first.`);
+        }
+        const decision = SM.assignmentDecision(target, uid, owners);
+        const previousTargetUids = decision.targetUids.slice();
+
+        if (decision.requiresConfirmation) {
+            const paragraphs = [];
+            if (decision.action === 'move') {
+                paragraphs.push(`${formatUid(uid)} is currently linked to ${describeSpool(owners[0])}. It will be removed there and linked to ${describeSpool(target)}.`);
+            } else if (decision.action === 'add_second') {
+                paragraphs.push(`${describeSpool(target)} already has RFID ${formatUid(previousTargetUids[0])}. Add ${formatUid(uid)} as its second RFID?`);
+            } else {
+                paragraphs.push(`${describeSpool(target)} already has ${previousTargetUids.length} RFID tags. Add ${formatUid(uid)} as another RFID?`);
+            }
+            if (decision.action === 'move' && previousTargetUids.length === 1) {
+                paragraphs.push('The target spool will have two RFID tags after this assignment.');
+            } else if (decision.action === 'move' && previousTargetUids.length >= 2) {
+                paragraphs.push(`Warning: the target already has ${previousTargetUids.length} RFID tags. This creates an additional tag association.`);
+            }
+            const accepted = await requestRfidConfirmation(
+                decision.action === 'add_second'
+                    ? 'Add Second RFID'
+                    : (decision.action === 'add_extra' ? 'Add Another RFID' : 'Confirm RFID Move'),
+                paragraphs,
+                decision.confirmLabel,
+            );
+            if (!accepted) return;
+            ensureChannelUid(channel, uid);
+        }
+
+        closeModal('spoolman-modal');
         showStatus('Assigning spool…', 'info');
-        await sendGcode(`SET_SPOOL_ID LANE=E${channel} SPOOL_ID=${spoolId}`);
-        const spool = await fetchSpoolmanSpool(spoolId);
-        if (spool) spoolmanSpools.set(spoolId, spool);
+        await executeSpoolAssignment(channel, target, uid, previousTargetUids);
         showStatus(`Spool #${spoolId} assigned to Extruder ${channel + 1}`, 'success');
     } catch (err) {
         showStatus(`Failed to assign spool: ${err.message}`, 'error');
+    } finally {
+        spoolAssignmentBusy = false;
     }
 }
 
@@ -742,10 +961,327 @@ async function clearSpoolForChannel(channel) {
     closeModal('spoolman-modal');
     try {
         showStatus('Clearing spool…', 'info');
-        await sendGcode(`SET_SPOOL_ID LANE=E${channel} SPOOL_ID=0`);
+        await sendGcode(`SET_SPOOL_ID LANE=E${channel} CHANNEL=${channel} SPOOL_ID=0`);
         showStatus(`Extruder ${channel + 1} spool cleared`, 'success');
     } catch (err) {
         showStatus(`Failed to clear spool: ${err.message}`, 'error');
+    }
+}
+
+// ── Spool creation and RFID assignment ─────────────────────────────────────
+
+// Create a Spoolman spool from metadata reported by the U1 RFID reader.
+// Spoolman record creation is direct; RFID assignment still goes through
+// SET_SPOOL_ID so SpoolLink remains the single writer for UID movement.
+function setCreateSpoolNotice(message, type = 'warning') {
+    const notice = document.getElementById('create-spool-notice');
+    notice.textContent = message || '';
+    notice.className = `create-spool-notice${type === 'error' ? ' error' : ''}`;
+    notice.style.display = message ? '' : 'none';
+}
+
+function setCreateFilamentFieldsLocked(locked) {
+    document.querySelectorAll('#create-spool-filament-fields input').forEach(input => {
+        input.disabled = locked;
+    });
+}
+
+function setCreateFormValues(values) {
+    const form = document.getElementById('create-spool-form');
+    for (const name of [
+        'vendor', 'material', 'variant', 'name', 'color', 'diameter', 'density',
+        'nozzle_temp', 'bed_temp', 'net_weight', 'tare_weight',
+    ]) {
+        if (values[name] !== undefined) form.elements[name].value = values[name] ?? '';
+    }
+}
+
+function createDefaultsFromChannel(channel) {
+    const metadata = channel.rfid_data || {};
+    const reportedWeight = SM.finiteNumber(metadata.weight);
+    return {
+        vendor: SM.cleanText(metadata.vendor),
+        material: SM.cleanText(metadata.type),
+        variant: SM.cleanText(metadata.variant || metadata.sub_type),
+        name: SM.defaultFilamentName({
+            material: metadata.type,
+            variant: metadata.variant || metadata.sub_type,
+            color: metadata.color,
+        }),
+        color: SM.normalizeColor(metadata.color),
+        diameter: SM.finiteNumber(metadata.diameter) || 1.75,
+        density: SM.materialDensity(metadata.type, metadata.density),
+        nozzle_temp: SM.finiteNumber(metadata.max_temp) || '',
+        bed_temp: SM.finiteNumber(metadata.bed_temp) || '',
+        net_weight: reportedWeight != null && reportedWeight > 0 ? reportedWeight : 1000,
+        tare_weight: '',
+    };
+}
+
+function valuesFromFilament(filament) {
+    return {
+        vendor: filament?.vendor?.name || '',
+        material: filament?.material || '',
+        variant: SM.parseVariant(filament),
+        name: filament?.name || '',
+        color: SM.normalizeColor(filament?.color_hex),
+        diameter: filament?.diameter ?? '',
+        density: filament?.density ?? '',
+        nozzle_temp: filament?.settings_extruder_temp ?? '',
+        bed_temp: filament?.settings_bed_temp ?? '',
+        tare_weight: filament?.spool_weight ?? '',
+    };
+}
+
+function readCreateFormValues() {
+    const elements = document.getElementById('create-spool-form').elements;
+    return {
+        vendor: elements.vendor.value,
+        material: elements.material.value,
+        variant: elements.variant.value,
+        name: elements.name.value,
+        color: elements.color.value,
+        diameter: elements.diameter.value,
+        density: elements.density.value,
+        nozzle_temp: elements.nozzle_temp.value,
+        bed_temp: elements.bed_temp.value,
+        net_weight: elements.net_weight.value,
+        tare_weight: elements.tare_weight.value,
+    };
+}
+
+function setCreateSpoolLoading(loading) {
+    if (createSpoolContext) createSpoolContext.loading = loading;
+    const submit = document.getElementById('create-spool-submit');
+    submit.textContent = loading ? 'Working...' : 'Create and Assign';
+    const select = document.getElementById('create-spool-filament');
+    const needsSelection = !!(
+        createSpoolContext?.matches?.length > 1 &&
+        !Number(select.value)
+    );
+    submit.disabled = loading || needsSelection;
+    document.getElementById('create-spool-cancel').disabled = loading;
+    document.getElementById('create-spool-close').disabled = loading;
+}
+
+function configureCreateFilamentMatches(matches) {
+    if (!createSpoolContext) return;
+    createSpoolContext.matches = matches;
+    const section = document.getElementById('create-spool-match-section');
+    const select = document.getElementById('create-spool-filament');
+    const help = document.getElementById('create-spool-match-help');
+    select.innerHTML = '';
+
+    if (matches.length === 0) {
+        section.style.display = 'none';
+        select.required = false;
+        setCreateFilamentFieldsLocked(false);
+        setCreateSpoolLoading(false);
+        return;
+    }
+
+    section.style.display = '';
+    select.required = true;
+    setCreateFilamentFieldsLocked(true);
+    if (matches.length > 1) {
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Select one of the exact matches';
+        select.appendChild(placeholder);
+        help.textContent = 'More than one exact vendor/material/variant/colour match exists. Select the intended filament before creating the spool.';
+    } else {
+        help.textContent = 'An exact vendor/material/variant/colour match exists, so the existing filament record will be reused.';
+    }
+
+    for (const filament of matches) {
+        const option = document.createElement('option');
+        option.value = String(filament.id);
+        const vendor = filament.vendor?.name ? `${filament.vendor.name} - ` : '';
+        option.textContent = `${vendor}${filament.name || filament.material || 'Unnamed'} (#${filament.id})`;
+        select.appendChild(option);
+    }
+    if (matches.length === 1) {
+        select.value = String(matches[0].id);
+        setCreateFormValues(valuesFromFilament(matches[0]));
+    }
+    setCreateSpoolLoading(false);
+}
+
+function handleCreateFilamentSelection() {
+    if (!createSpoolContext) return;
+    const id = Number(document.getElementById('create-spool-filament').value);
+    const filament = createSpoolContext.matches.find(item => Number(item.id) === id);
+    if (filament) setCreateFormValues(valuesFromFilament(filament));
+    setCreateSpoolLoading(!!createSpoolContext.loading);
+}
+
+async function openCreateSpoolModal(channelNumber) {
+    const channel = channelsData.find(item => item.channel === channelNumber);
+    if (!channel || !SM.isCreateEligible(channel)) {
+        showStatus('A readable RFID with vendor, material, and colour is required', 'error');
+        return;
+    }
+
+    const uid = SM.normalizeUid(channel.uid);
+    const form = document.getElementById('create-spool-form');
+    form.reset();
+    document.getElementById('create-spool-title').textContent = `Create Spool - Extruder ${channelNumber + 1}`;
+    document.getElementById('create-spool-channel').textContent = String(channelNumber + 1);
+    document.getElementById('create-spool-uid').textContent = formatUid(uid);
+    setCreateFormValues(createDefaultsFromChannel(channel));
+    setCreateFilamentFieldsLocked(true);
+    document.getElementById('create-spool-match-section').style.display = 'none';
+    createSpoolContext = { channel: channelNumber, uid, metadata: channel.rfid_data, matches: [], loading: true };
+    setCreateSpoolNotice('Checking Spoolman for the RFID and an exact filament match...');
+    setCreateSpoolLoading(true);
+    openModal('create-spool-modal');
+
+    try {
+        const [spools, filaments] = await Promise.all([
+            fetchSpoolmanAllSpools(),
+            fetchSpoolmanFilaments(),
+        ]);
+        ensureChannelUid(channelNumber, uid);
+        storeSpoolmanInventory(spools, false);
+        const owners = SM.findUidOwners(spools, uid);
+        if (owners.length > 0) {
+            rebuildFromCache();
+            closeModal('create-spool-modal');
+            createSpoolContext = null;
+            const ownerText = owners.map(owner => `#${owner.id}`).join(', ');
+            showStatus(`RFID ${formatUid(uid)} already belongs to Spoolman spool ${ownerText}`, 'error');
+            return;
+        }
+        const matches = SM.findMatchingFilaments(filaments, {
+            vendor: channel.rfid_data.vendor,
+            material: channel.rfid_data.type,
+            variant: channel.rfid_data.variant || channel.rfid_data.sub_type,
+            color: channel.rfid_data.color,
+        });
+        setCreateSpoolNotice('');
+        configureCreateFilamentMatches(matches);
+    } catch (err) {
+        setCreateSpoolNotice(`Cannot prepare spool creation: ${err.message}`, 'error');
+        setCreateSpoolLoading(false);
+        document.getElementById('create-spool-submit').disabled = true;
+    }
+}
+
+function closeCreateSpoolModal() {
+    if (createSpoolContext?.loading) return;
+    closeModal('create-spool-modal');
+    createSpoolContext = null;
+}
+
+async function handleCreateSpool(event) {
+    event.preventDefault();
+    if (!createSpoolContext || createSpoolContext.loading) return;
+    const context = createSpoolContext;
+    const form = event.currentTarget;
+    if (!form.reportValidity()) return;
+
+    const createdRecords = [];
+    let createdSpoolId = null;
+    setCreateSpoolLoading(true);
+    setCreateSpoolNotice('Rechecking Spoolman and the RFID before creating records...');
+
+    try {
+        ensureChannelUid(context.channel, context.uid);
+        const [spools, vendors, filaments] = await Promise.all([
+            fetchSpoolmanAllSpools(),
+            fetchSpoolmanVendors(),
+            fetchSpoolmanFilaments(),
+        ]);
+        storeSpoolmanInventory(spools, false);
+        ensureChannelUid(context.channel, context.uid);
+
+        const owners = SM.findUidOwners(spools, context.uid);
+        if (owners.length > 1) {
+            throw new Error(`RFID ${formatUid(context.uid)} is stored on multiple spools (${owners.map(owner => `#${owner.id}`).join(', ')}). Resolve the duplicate in Spoolman first.`);
+        }
+        if (owners.length === 1) {
+            const owner = owners[0];
+            setCreateSpoolNotice(`The RFID was linked to spool #${owner.id} while this dialog was open. Assigning that existing spool instead.`);
+            await executeSpoolAssignment(context.channel, owner, context.uid, SM.parseCardUids(owner));
+            closeModal('create-spool-modal');
+            createSpoolContext = null;
+            showStatus(`Existing spool #${owner.id} assigned to Extruder ${context.channel + 1}`, 'success');
+            return;
+        }
+
+        const values = readCreateFormValues();
+        const selectedId = Number(document.getElementById('create-spool-filament').value);
+        let filament = selectedId
+            ? filaments.find(item => Number(item.id) === selectedId)
+            : null;
+        if (selectedId && !filament) throw new Error(`Selected filament #${selectedId} no longer exists`);
+        if (filament && SM.findMatchingFilaments([filament], {
+            vendor: context.metadata.vendor,
+            material: context.metadata.type,
+            variant: context.metadata.variant || context.metadata.sub_type,
+            color: context.metadata.color,
+        }).length !== 1) {
+            throw new Error(`Selected filament #${selectedId} no longer matches the RFID metadata`);
+        }
+
+        if (!filament) {
+            const currentMatches = SM.findMatchingFilaments(filaments, values);
+            if (currentMatches.length === 1) {
+                filament = currentMatches[0];
+            } else if (currentMatches.length > 1) {
+                configureCreateFilamentMatches(currentMatches);
+                throw new Error('Multiple exact filament matches now exist. Select the intended record and submit again.');
+            } else {
+                const vendorName = SM.cleanText(values.vendor);
+                if (!vendorName) throw new Error('Vendor is required');
+                const orderedVendors = vendors.slice().sort((left, right) =>
+                    Number(!!(left.archived || left.is_archived)) - Number(!!(right.archived || right.is_archived)) ||
+                    Number(left.id) - Number(right.id));
+                let vendor = orderedVendors.find(item => SM.normalizeText(item.name) === SM.normalizeText(vendorName));
+                if (!vendor) {
+                    vendor = await spoolmanRequest('POST', '/v1/vendor', { body: { name: vendorName } });
+                    if (!vendor?.id) throw new Error('Spoolman did not return the created vendor ID');
+                    createdRecords.push(`vendor #${vendor.id}`);
+                }
+                const payload = SM.buildFilamentPayload(values, vendor.id);
+                filament = await spoolmanRequest('POST', '/v1/filament', { body: payload });
+                if (!filament?.id) throw new Error('Spoolman did not return the created filament ID');
+                createdRecords.push(`filament #${filament.id}`);
+            }
+        }
+
+        const spoolPayload = SM.buildSpoolPayload(filament.id, {
+            uid: context.uid,
+            net_weight: values.net_weight,
+            tare_weight: values.tare_weight,
+        });
+        const createdSpool = await spoolmanRequest('POST', '/v1/spool', { body: spoolPayload });
+        if (!createdSpool?.id) throw new Error('Spoolman did not return the created spool ID');
+        createdSpoolId = Number(createdSpool.id);
+        createdRecords.push(`spool #${createdSpoolId}`);
+
+        ensureChannelUid(context.channel, context.uid);
+        const postCreateSpools = await fetchSpoolmanAllSpools();
+        storeSpoolmanInventory(postCreateSpools, false);
+        const postCreateOwners = SM.findUidOwners(postCreateSpools, context.uid);
+        if (postCreateOwners.length !== 1 || Number(postCreateOwners[0].id) !== createdSpoolId) {
+            throw new Error('RFID ownership changed during creation; no assignment was attempted');
+        }
+        setCreateSpoolNotice(`Spool #${createdSpoolId} created. Assigning and verifying its RFID...`);
+        await executeSpoolAssignment(context.channel, createdSpool, context.uid, [context.uid]);
+        closeModal('create-spool-modal');
+        createSpoolContext = null;
+        showStatus(`Spool #${createdSpoolId} created and assigned to Extruder ${context.channel + 1}`, 'success');
+    } catch (err) {
+        const retained = createdRecords.length
+            ? ` Created records were retained for a safe retry: ${createdRecords.join(', ')}.`
+            : '';
+        const prefix = createdSpoolId != null ? `Spool #${createdSpoolId} was created, but assignment failed. ` : '';
+        const message = `${prefix}${err.message}.${retained}`.replace('..', '.');
+        setCreateSpoolNotice(message, 'error');
+        showStatus(`Create spool failed: ${err.message}`, 'error');
+    } finally {
+        if (createSpoolContext === context) setCreateSpoolLoading(false);
     }
 }
 
@@ -822,10 +1358,30 @@ function closeModal(id) {
 function initializeModals() {
     document.addEventListener('keydown', e => {
         if (e.key === 'Escape') {
+            if (document.getElementById('rfid-confirm-modal').style.display !== 'none') {
+                resolveRfidConfirmation(false);
+                return;
+            }
             closeModal('overwrite-modal'); closeModal('spoolman-modal');
             closeModal('mismatch-modal');
+            closeCreateSpoolModal();
         }
     });
+
+    document.getElementById('rfid-confirm-close').addEventListener('click', () => resolveRfidConfirmation(false));
+    document.getElementById('rfid-confirm-cancel').addEventListener('click', () => resolveRfidConfirmation(false));
+    document.getElementById('rfid-confirm-accept').addEventListener('click', () => resolveRfidConfirmation(true));
+    document.getElementById('rfid-confirm-modal').addEventListener('click', e => {
+        if (e.target.id === 'rfid-confirm-modal') resolveRfidConfirmation(false);
+    });
+
+    document.getElementById('create-spool-close').addEventListener('click', closeCreateSpoolModal);
+    document.getElementById('create-spool-cancel').addEventListener('click', closeCreateSpoolModal);
+    document.getElementById('create-spool-modal').addEventListener('click', e => {
+        if (e.target.id === 'create-spool-modal') closeCreateSpoolModal();
+    });
+    document.getElementById('create-spool-form').addEventListener('submit', handleCreateSpool);
+    document.getElementById('create-spool-filament').addEventListener('change', handleCreateFilamentSelection);
 
     document.getElementById('mismatch-close').addEventListener('click', () => closeModal('mismatch-modal'));
     document.getElementById('mismatch-cancel').addEventListener('click', () => closeModal('mismatch-modal'));

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/script.js
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/script.js
@@ -4,6 +4,9 @@
 
 'use strict';
 
+const SM = window.SpoolmanUtils;
+if (!SM) throw new Error('spoolman-utils.js failed to load');
+
 // Subscribe to all fields so we get state[] push updates too
 const QUERY_OBJECTS = {
     filament_detect: null,
@@ -25,12 +28,17 @@ let spoolmanActive = false;
 let spoolmanUrl = null;
 let forceGenericVendor = false;
 let spoolmanSpools = new Map();
+let spoolmanInventory = [];
+let spoolmanInventoryLoaded = false;
 let spoolPickerChannel = null;
 let spoolRefreshTimer = null;
 const SPOOL_REFRESH_ACTIVE_MS = 3000;
 const SPOOL_REFRESH_IDLE_MS = 30000;
 let spoolPickerSpools = [];
 let spoolPickerCurrentId = null;
+let spoolAssignmentBusy = false;
+let createSpoolContext = null;
+let rfidConfirmationResolve = null;
 
 // Last known full status — merged incrementally from notify_status_update
 let cachedStatus = {
@@ -179,27 +187,23 @@ function setConnectionStatus(connected) {
 
 // ── Initial data load (no gcodes — shows existing printer state) ──────────
 
-function loadSpoolmanStatus() {
-    sendRPC('server.spoolman.status').then(status => {
-        if (status.spoolman_connected) {
-            spoolmanActive = true;
-            if (!spoolRefreshTimer) scheduleSpoolRefresh();
-        }
-    }).catch(() => {});
+async function loadSpoolmanStatus() {
+    const [status, config] = await Promise.all([
+        sendRPC('server.spoolman.status').catch(() => null),
+        sendRPC('server.config').catch(() => null),
+    ]);
+    spoolmanActive = !!status?.spoolman_connected;
+    spoolmanUrl = config?.config?.spoolman?.server || null;
 
-    sendRPC('server.config').then(config => {
-        spoolmanUrl = config.config?.spoolman?.server || null;
+    const rawForceGeneric = config?.config?.spoollink?.force_generic_vendor;
+    forceGenericVendor =
+        rawForceGeneric === true ||
+        String(rawForceGeneric).toLowerCase() === 'true';
 
-        const rawForceGeneric =
-            config.config?.spoollink?.force_generic_vendor;
-
-        forceGenericVendor =
-            rawForceGeneric === true ||
-            String(rawForceGeneric).toLowerCase() === 'true';
-
-        // Config may arrive after the first channel render.
-        rebuildFromCache();
-    }).catch(() => {});
+    if (spoolmanActive) {
+        if (!spoolRefreshTimer) scheduleSpoolRefresh();
+        await refreshSpoolmanInventory(false).catch(() => {});
+    }
 }
 
 async function loadInitialData() {
@@ -213,17 +217,73 @@ async function loadInitialData() {
     }
 }
 
+async function spoolmanRequest(requestMethod, path, options = {}) {
+    const params = {
+        request_method: requestMethod,
+        path,
+        use_v2_response: true,
+    };
+    if (options.query) params.query = options.query;
+    if (options.body !== undefined) params.body = options.body;
+
+    const result = await sendRPC('server.spoolman.proxy', params);
+    if (result?.error) {
+        const status = result.error.status_code ? ` (${result.error.status_code})` : '';
+        throw new Error(`${result.error.message || 'Spoolman request failed'}${status}`);
+    }
+    return result?.response;
+}
+
 async function fetchSpoolmanAllSpools() {
-    try {
-        const result = await sendRPC('server.spoolman.proxy', { request_method: 'GET', path: '/v1/spool' });
-        return Array.isArray(result) ? result : [];
-    } catch { return []; }
+    const result = await spoolmanRequest('GET', '/v1/spool', {
+        query: 'limit=1000&allow_archived=true',
+    });
+    if (!Array.isArray(result)) throw new Error('Spoolman returned an invalid spool list');
+    return result;
 }
 
 async function fetchSpoolmanSpool(id) {
-    try {
-        return await sendRPC('server.spoolman.proxy', { request_method: 'GET', path: `/v1/spool/${id}` });
-    } catch { return null; }
+    return await spoolmanRequest('GET', `/v1/spool/${id}`);
+}
+
+async function fetchSpoolmanVendors() {
+    const result = await spoolmanRequest('GET', '/v1/vendor', {
+        query: 'limit=1000&allow_archived=true',
+    });
+    if (!Array.isArray(result)) throw new Error('Spoolman returned an invalid vendor list');
+    return result;
+}
+
+async function fetchSpoolmanFilaments() {
+    const result = await spoolmanRequest('GET', '/v1/filament', {
+        query: 'limit=1000&allow_archived=true',
+    });
+    if (!Array.isArray(result)) throw new Error('Spoolman returned an invalid filament list');
+    return result;
+}
+
+function storeSpoolmanInventory(spools, rerender = true) {
+    spoolmanInventory = spools;
+    spoolmanInventoryLoaded = true;
+    spoolmanSpools = new Map(spools.map(spool => [Number(spool.id), spool]));
+    if (rerender) rebuildFromCache();
+}
+
+async function refreshSpoolmanInventory(rerender = true) {
+    const spools = await fetchSpoolmanAllSpools();
+    storeSpoolmanInventory(spools, rerender);
+    return spools;
+}
+
+function upsertSpoolmanSpool(spool) {
+    if (!spool) return;
+    const id = Number(spool.id);
+    spoolmanSpools.set(id, spool);
+    if (spoolmanInventoryLoaded) {
+        const index = spoolmanInventory.findIndex(item => Number(item.id) === id);
+        if (index === -1) spoolmanInventory.push(spool);
+        else spoolmanInventory[index] = spool;
+    }
 }
 
 async function refreshSpoolWeights() {
@@ -231,8 +291,9 @@ async function refreshSpoolWeights() {
     const activeIds = [...new Set(channelsData.map(ch => ch.spool_id).filter(id => id != null))];
     if (activeIds.length === 0) return;
     await Promise.all(activeIds.map(async id => {
-        const spool = await fetchSpoolmanSpool(id);
-        if (spool) spoolmanSpools.set(id, spool);
+        try {
+            upsertSpoolmanSpool(await fetchSpoolmanSpool(id));
+        } catch {}
     }));
     rebuildFromCache();
 }
@@ -279,6 +340,7 @@ async function refreshAllChannels() {
         for (let i = 0; i < 4; i++) gcodes.push(`FILAMENT_DT_CLEAR CHANNEL=${i}`);
         for (let i = 0; i < 4; i++) gcodes.push(`FILAMENT_DT_UPDATE CHANNEL=${i}`);
         await sendGcode(gcodes.join('\n'));
+        if (spoolmanActive) await refreshSpoolmanInventory(false).catch(() => {});
     } catch (err) {
         showStatus(`Refresh failed: ${err.message}`, 'error');
     } finally {
@@ -291,6 +353,7 @@ async function refreshSingleChannel(channel) {
     if (!wsReady) { showStatus('Waiting for connection…', 'info'); return; }
     try {
         await sendGcode(`FILAMENT_DT_CLEAR CHANNEL=${channel}\nFILAMENT_DT_UPDATE CHANNEL=${channel}`);
+        if (spoolmanActive) await refreshSpoolmanInventory(false).catch(() => {});
     } catch (err) {
         showStatus(`Refresh failed: ${err.message}`, 'error');
     }
@@ -347,9 +410,11 @@ function parseChannelInfo(i, fd, fdState, ptc) {
     // unless the tag actually carries filament data (a material type or vendor).
     const rfidVendor  = fd.VENDOR && fd.VENDOR !== 'NONE' ? fd.VENDOR : null;
     const rfidHasData = !!(fdMainType || rfidVendor);
+    const rawRfidSubtype = fd.SUB_TYPE && fd.SUB_TYPE !== 'NONE' ? fd.SUB_TYPE : null;
     const rfidData = hasUid ? {
         type:     fdMainType,
-        sub_type: fd.SUB_TYPE && fd.SUB_TYPE !== 'NONE' && fd.SUB_TYPE !== 'Basic' ? fd.SUB_TYPE : null,
+        sub_type: rawRfidSubtype && rawRfidSubtype !== 'Basic' ? rawRfidSubtype : null,
+        variant:  rawRfidSubtype,
         vendor:   rfidVendor,
         color:    rfidHasData && fd.RGB_1 != null ? (fd.RGB_1 & 0xFFFFFF).toString(16).padStart(6, '0').toUpperCase() : null,
         min_temp: rfidHasData ? (fd.HOTEND_MIN_TEMP || null) : null,
@@ -357,6 +422,7 @@ function parseChannelInfo(i, fd, fdState, ptc) {
         bed_temp: rfidHasData ? (fd.BED_TEMP        || null) : null,
         diameter: rfidHasData && fd.DIAMETER ? fd.DIAMETER / 100.0 : null,
         density:  rfidHasData ? (fd.DENSITY         || null) : null,
+        weight:   rfidHasData ? (fd.WEIGHT          || null) : null,
     } : null;
 
     const cmpStr = (a, b) => !!(a && b && a.toLowerCase() !== b.toLowerCase());
@@ -441,7 +507,7 @@ function createChannelCard(channel) {
 
     const displayCh = channel.channel + 1;
     const { present, filament_exists: filamentExists, official: isOfficial,
-            empty: isEmpty, malformed: isMalformed, filament, card_type, uid,
+            malformed: isMalformed, filament, card_type, uid,
             spool_id: spoolId, mismatch, display_vendor: displayVendor,
             ptc_sources: ptcSources } = channel;
     const hasUid = uid.length > 0;
@@ -495,6 +561,8 @@ function createChannelCard(channel) {
                 }
                 if (spool.remaining_weight != null) rows.push({ label: 'Remaining', value: `${Math.round(spool.remaining_weight)} g` });
                 if (spool.filament.weight  != null) rows.push({ label: 'Total',     value: `${spool.filament.weight} g` });
+                const storedUids = SM.parseCardUids(spool);
+                rows.push({ label: 'RFID tags', value: String(storedUids.length) });
                 showPopover(b, rows);
             });
             b.addEventListener('mouseleave', hidePopover);
@@ -597,6 +665,9 @@ function createChannelCard(channel) {
             addRow('Remaining', filament.remaining_weight != null
                 ? `<span class="spool-remaining">${filament.remaining_weight} g</span>`
                 : na);
+            const activeSpool = spoolId != null ? spoolmanSpools.get(Number(spoolId)) : null;
+            const storedUidCount = activeSpool ? SM.parseCardUids(activeSpool).length : null;
+            addRow('RFID tags', storedUidCount != null ? `${storedUidCount} stored` : na);
         }
 
         if (isMalformed) {
@@ -640,6 +711,17 @@ function createChannelCard(channel) {
     actions.appendChild(mkBtn('↻ Refresh', '', () => refreshSingleChannel(channel.channel)));
     actions.appendChild(mkBtn('✎ User', '', () => openOverwriteModal(channel.channel)));
     actions.appendChild(mkBtn('Reset', '', () => resetChannel(channel.channel)));
+    if (spoolmanActive && SM.isCreateEligible(channel)) {
+        const owners = spoolmanInventoryLoaded
+            ? SM.findUidOwners(spoolmanInventory, uid)
+            : [];
+        if (!spoolmanInventoryLoaded || owners.length === 0) {
+            const createBtn = mkBtn('+ Create Spool', 'create-spool-btn', () => openCreateSpoolModal(channel.channel));
+            createBtn.disabled = !spoolmanInventoryLoaded;
+            if (createBtn.disabled) createBtn.title = 'Waiting for the Spoolman inventory';
+            actions.appendChild(createBtn);
+        }
+    }
     if (spoolmanActive) actions.appendChild(mkBtn('⊕ Spool', '', () => openSpoolPicker(channel.channel)));
 
     card.appendChild(actions);
@@ -710,6 +792,94 @@ function copyToClipboard(text) {
     });
 }
 
+function currentChannelUid(channel) {
+    const current = channelsData.find(item => item.channel === channel);
+    return SM.normalizeUid(current?.uid);
+}
+
+function formatUid(uid) {
+    const normalized = SM.normalizeUid(uid);
+    return normalized ? normalized.match(/.{2}/g).join(':') : 'none';
+}
+
+function describeSpool(spool) {
+    const name = spool?.filament?.name || spool?.filament?.material || 'Unknown filament';
+    return `Spool #${spool?.id} (${name})`;
+}
+
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function ensureChannelUid(channel, expectedUid) {
+    const actualUid = currentChannelUid(channel);
+    if (actualUid !== SM.normalizeUid(expectedUid)) {
+        throw new Error(`The RFID in Extruder ${channel + 1} changed. Read the spool tag again before continuing.`);
+    }
+}
+
+function resolveRfidConfirmation(accepted) {
+    closeModal('rfid-confirm-modal');
+    if (!rfidConfirmationResolve) return;
+    const resolve = rfidConfirmationResolve;
+    rfidConfirmationResolve = null;
+    resolve(accepted);
+}
+
+function requestRfidConfirmation(title, paragraphs, confirmLabel) {
+    if (rfidConfirmationResolve) resolveRfidConfirmation(false);
+    document.getElementById('rfid-confirm-title').textContent = title;
+    document.getElementById('rfid-confirm-accept').textContent = confirmLabel;
+    const content = document.getElementById('rfid-confirm-content');
+    content.innerHTML = '';
+    for (const paragraph of paragraphs) {
+        const element = document.createElement('p');
+        element.textContent = paragraph;
+        content.appendChild(element);
+    }
+    openModal('rfid-confirm-modal');
+    return new Promise(resolve => { rfidConfirmationResolve = resolve; });
+}
+
+async function waitForRfidAssignment(targetId, uid, previousTargetUids) {
+    let lastVerification = null;
+    let lastError = null;
+    for (let attempt = 0; attempt < 4; attempt++) {
+        if (attempt > 0) await delay(250 * (2 ** (attempt - 1)));
+        try {
+            const spools = await fetchSpoolmanAllSpools();
+            storeSpoolmanInventory(spools, false);
+            lastVerification = SM.verifyUidAssignment(spools, targetId, uid, previousTargetUids);
+            if (lastVerification.ok) {
+                rebuildFromCache();
+                return lastVerification;
+            }
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    rebuildFromCache();
+    if (lastError && !lastVerification) throw lastError;
+    const owners = lastVerification?.ownerIds?.length
+        ? lastVerification.ownerIds.map(id => `#${id}`).join(', ')
+        : 'none';
+    const missing = lastVerification?.missingPrevious?.length
+        ? ` Previous target UID(s) missing: ${lastVerification.missingPrevious.join(', ')}.`
+        : '';
+    throw new Error(`RFID assignment could not be verified (current owner(s): ${owners}).${missing}`);
+}
+
+async function executeSpoolAssignment(channel, targetSpool, uid, previousTargetUids) {
+    ensureChannelUid(channel, uid);
+    await sendGcode(`SET_SPOOL_ID LANE=E${channel} CHANNEL=${channel} SPOOL_ID=${targetSpool.id}`);
+    if (uid) {
+        await waitForRfidAssignment(targetSpool.id, uid, previousTargetUids);
+    } else {
+        upsertSpoolmanSpool(await fetchSpoolmanSpool(targetSpool.id));
+        rebuildFromCache();
+    }
+}
+
 async function openSpoolPicker(channel) {
     spoolPickerChannel = channel;
     document.getElementById('spoolman-modal-title').textContent = `Pick Spool — Extruder ${channel + 1}`;
@@ -718,18 +888,22 @@ async function openSpoolPicker(channel) {
     list.innerHTML = '<div class="spoolman-loading"><span class="spinner"></span> Loading…</div>';
     openModal('spoolman-modal');
 
-    const spools = await fetchSpoolmanAllSpools();
-    spoolPickerSpools = spools;
-    const ch = channelsData.find(c => c.channel === channel);
-    spoolPickerCurrentId = ch ? ch.spool_id : null;
-    renderSpoolList('');
+    try {
+        const spools = await refreshSpoolmanInventory(false);
+        spoolPickerSpools = spools;
+        const ch = channelsData.find(c => c.channel === channel);
+        spoolPickerCurrentId = ch ? ch.spool_id : null;
+        renderSpoolList('');
+    } catch (err) {
+        list.innerHTML = `<div class="spoolman-empty">${escHtml(`Failed to load Spoolman: ${err.message}`)}</div>`;
+    }
 }
 
 function renderSpoolList(filter) {
     const list = document.getElementById('spoolman-list');
     const lower = filter.toLowerCase();
     const filtered = spoolPickerSpools.filter(s => {
-        if (s.is_archived) return false;
+        if (s.archived || s.is_archived) return false;
         if (!lower) return true;
         const name    = (s.filament.name     || '').toLowerCase();
         const material= (s.filament.material || '').toLowerCase();
@@ -759,6 +933,7 @@ function renderSpoolList(filter) {
         const swatchesHtml = swatchColors
             .map(c => `<div class="spoolman-swatch" style="background:#${escHtml(c)}"></div>`)
             .join('');
+        const rfidCount = SM.parseCardUids(s).length;
         item.innerHTML =
             `<div class="spoolman-swatches">${swatchesHtml}</div>` +
             `<div class="spoolman-info">` +
@@ -768,6 +943,7 @@ function renderSpoolList(filter) {
             `<div class="spoolman-right">` +
                 `<div class="spoolman-weight">${escHtml(weight)}</div>` +
                 `<div class="spoolman-id">#${s.id}</div>` +
+                `<div class="spoolman-rfid-count">${rfidCount} RFID tag${rfidCount === 1 ? '' : 's'}</div>` +
             `</div>`;
         item.addEventListener('click', () => pickSpool(s.id));
         list.appendChild(item);
@@ -775,17 +951,56 @@ function renderSpoolList(filter) {
 }
 
 async function pickSpool(spoolId) {
-    if (spoolPickerChannel === null) return;
+    if (spoolPickerChannel === null || spoolAssignmentBusy) return;
+    spoolAssignmentBusy = true;
     const channel = spoolPickerChannel;
-    closeModal('spoolman-modal');
     try {
+        const uid = currentChannelUid(channel);
+        const spools = await refreshSpoolmanInventory(false);
+        ensureChannelUid(channel, uid);
+        const target = spools.find(spool => Number(spool.id) === Number(spoolId));
+        if (!target) throw new Error(`Spool #${spoolId} no longer exists`);
+
+        const owners = uid ? SM.findUidOwners(spools, uid) : [];
+        if (owners.length > 1) {
+            throw new Error(`RFID ${formatUid(uid)} is already stored on multiple spools (${owners.map(owner => `#${owner.id}`).join(', ')}). Resolve the duplicate in Spoolman first.`);
+        }
+        const decision = SM.assignmentDecision(target, uid, owners);
+        const previousTargetUids = decision.targetUids.slice();
+
+        if (decision.requiresConfirmation) {
+            const paragraphs = [];
+            if (decision.action === 'move') {
+                paragraphs.push(`${formatUid(uid)} is currently linked to ${describeSpool(owners[0])}. It will be removed there and linked to ${describeSpool(target)}.`);
+            } else if (decision.action === 'add_second') {
+                paragraphs.push(`${describeSpool(target)} already has RFID ${formatUid(previousTargetUids[0])}. Add ${formatUid(uid)} as its second RFID?`);
+            } else {
+                paragraphs.push(`${describeSpool(target)} already has ${previousTargetUids.length} RFID tags. Add ${formatUid(uid)} as another RFID?`);
+            }
+            if (decision.action === 'move' && previousTargetUids.length === 1) {
+                paragraphs.push('The target spool will have two RFID tags after this assignment.');
+            } else if (decision.action === 'move' && previousTargetUids.length >= 2) {
+                paragraphs.push(`Warning: the target already has ${previousTargetUids.length} RFID tags. This creates an additional tag association.`);
+            }
+            const accepted = await requestRfidConfirmation(
+                decision.action === 'add_second'
+                    ? 'Add Second RFID'
+                    : (decision.action === 'add_extra' ? 'Add Another RFID' : 'Confirm RFID Move'),
+                paragraphs,
+                decision.confirmLabel,
+            );
+            if (!accepted) return;
+            ensureChannelUid(channel, uid);
+        }
+
+        closeModal('spoolman-modal');
         showStatus('Assigning spool…', 'info');
-        await sendGcode(`SET_SPOOL_ID LANE=E${channel} SPOOL_ID=${spoolId}`);
-        const spool = await fetchSpoolmanSpool(spoolId);
-        if (spool) spoolmanSpools.set(spoolId, spool);
+        await executeSpoolAssignment(channel, target, uid, previousTargetUids);
         showStatus(`Spool #${spoolId} assigned to Extruder ${channel + 1}`, 'success');
     } catch (err) {
         showStatus(`Failed to assign spool: ${err.message}`, 'error');
+    } finally {
+        spoolAssignmentBusy = false;
     }
 }
 
@@ -793,10 +1008,327 @@ async function clearSpoolForChannel(channel) {
     closeModal('spoolman-modal');
     try {
         showStatus('Clearing spool…', 'info');
-        await sendGcode(`SET_SPOOL_ID LANE=E${channel} SPOOL_ID=0`);
+        await sendGcode(`SET_SPOOL_ID LANE=E${channel} CHANNEL=${channel} SPOOL_ID=0`);
         showStatus(`Extruder ${channel + 1} spool cleared`, 'success');
     } catch (err) {
         showStatus(`Failed to clear spool: ${err.message}`, 'error');
+    }
+}
+
+// ── Spool creation and RFID assignment ─────────────────────────────────────
+
+// Create a Spoolman spool from metadata reported by the U1 RFID reader.
+// Spoolman record creation is direct; RFID assignment still goes through
+// SET_SPOOL_ID so SpoolLink remains the single writer for UID movement.
+function setCreateSpoolNotice(message, type = 'warning') {
+    const notice = document.getElementById('create-spool-notice');
+    notice.textContent = message || '';
+    notice.className = `create-spool-notice${type === 'error' ? ' error' : ''}`;
+    notice.style.display = message ? '' : 'none';
+}
+
+function setCreateFilamentFieldsLocked(locked) {
+    document.querySelectorAll('#create-spool-filament-fields input').forEach(input => {
+        input.disabled = locked;
+    });
+}
+
+function setCreateFormValues(values) {
+    const form = document.getElementById('create-spool-form');
+    for (const name of [
+        'vendor', 'material', 'variant', 'name', 'color', 'diameter', 'density',
+        'nozzle_temp', 'bed_temp', 'net_weight', 'tare_weight',
+    ]) {
+        if (values[name] !== undefined) form.elements[name].value = values[name] ?? '';
+    }
+}
+
+function createDefaultsFromChannel(channel) {
+    const metadata = channel.rfid_data || {};
+    const reportedWeight = SM.finiteNumber(metadata.weight);
+    return {
+        vendor: SM.cleanText(metadata.vendor),
+        material: SM.cleanText(metadata.type),
+        variant: SM.cleanText(metadata.variant || metadata.sub_type),
+        name: SM.defaultFilamentName({
+            material: metadata.type,
+            variant: metadata.variant || metadata.sub_type,
+            color: metadata.color,
+        }),
+        color: SM.normalizeColor(metadata.color),
+        diameter: SM.finiteNumber(metadata.diameter) || 1.75,
+        density: SM.materialDensity(metadata.type, metadata.density),
+        nozzle_temp: SM.finiteNumber(metadata.max_temp) || '',
+        bed_temp: SM.finiteNumber(metadata.bed_temp) || '',
+        net_weight: reportedWeight != null && reportedWeight > 0 ? reportedWeight : 1000,
+        tare_weight: '',
+    };
+}
+
+function valuesFromFilament(filament) {
+    return {
+        vendor: filament?.vendor?.name || '',
+        material: filament?.material || '',
+        variant: SM.parseVariant(filament),
+        name: filament?.name || '',
+        color: SM.normalizeColor(filament?.color_hex),
+        diameter: filament?.diameter ?? '',
+        density: filament?.density ?? '',
+        nozzle_temp: filament?.settings_extruder_temp ?? '',
+        bed_temp: filament?.settings_bed_temp ?? '',
+        tare_weight: filament?.spool_weight ?? '',
+    };
+}
+
+function readCreateFormValues() {
+    const elements = document.getElementById('create-spool-form').elements;
+    return {
+        vendor: elements.vendor.value,
+        material: elements.material.value,
+        variant: elements.variant.value,
+        name: elements.name.value,
+        color: elements.color.value,
+        diameter: elements.diameter.value,
+        density: elements.density.value,
+        nozzle_temp: elements.nozzle_temp.value,
+        bed_temp: elements.bed_temp.value,
+        net_weight: elements.net_weight.value,
+        tare_weight: elements.tare_weight.value,
+    };
+}
+
+function setCreateSpoolLoading(loading) {
+    if (createSpoolContext) createSpoolContext.loading = loading;
+    const submit = document.getElementById('create-spool-submit');
+    submit.textContent = loading ? 'Working...' : 'Create and Assign';
+    const select = document.getElementById('create-spool-filament');
+    const needsSelection = !!(
+        createSpoolContext?.matches?.length > 1 &&
+        !Number(select.value)
+    );
+    submit.disabled = loading || needsSelection;
+    document.getElementById('create-spool-cancel').disabled = loading;
+    document.getElementById('create-spool-close').disabled = loading;
+}
+
+function configureCreateFilamentMatches(matches) {
+    if (!createSpoolContext) return;
+    createSpoolContext.matches = matches;
+    const section = document.getElementById('create-spool-match-section');
+    const select = document.getElementById('create-spool-filament');
+    const help = document.getElementById('create-spool-match-help');
+    select.innerHTML = '';
+
+    if (matches.length === 0) {
+        section.style.display = 'none';
+        select.required = false;
+        setCreateFilamentFieldsLocked(false);
+        setCreateSpoolLoading(false);
+        return;
+    }
+
+    section.style.display = '';
+    select.required = true;
+    setCreateFilamentFieldsLocked(true);
+    if (matches.length > 1) {
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Select one of the exact matches';
+        select.appendChild(placeholder);
+        help.textContent = 'More than one exact vendor/material/variant/colour match exists. Select the intended filament before creating the spool.';
+    } else {
+        help.textContent = 'An exact vendor/material/variant/colour match exists, so the existing filament record will be reused.';
+    }
+
+    for (const filament of matches) {
+        const option = document.createElement('option');
+        option.value = String(filament.id);
+        const vendor = filament.vendor?.name ? `${filament.vendor.name} - ` : '';
+        option.textContent = `${vendor}${filament.name || filament.material || 'Unnamed'} (#${filament.id})`;
+        select.appendChild(option);
+    }
+    if (matches.length === 1) {
+        select.value = String(matches[0].id);
+        setCreateFormValues(valuesFromFilament(matches[0]));
+    }
+    setCreateSpoolLoading(false);
+}
+
+function handleCreateFilamentSelection() {
+    if (!createSpoolContext) return;
+    const id = Number(document.getElementById('create-spool-filament').value);
+    const filament = createSpoolContext.matches.find(item => Number(item.id) === id);
+    if (filament) setCreateFormValues(valuesFromFilament(filament));
+    setCreateSpoolLoading(!!createSpoolContext.loading);
+}
+
+async function openCreateSpoolModal(channelNumber) {
+    const channel = channelsData.find(item => item.channel === channelNumber);
+    if (!channel || !SM.isCreateEligible(channel)) {
+        showStatus('A readable RFID with vendor, material, and colour is required', 'error');
+        return;
+    }
+
+    const uid = SM.normalizeUid(channel.uid);
+    const form = document.getElementById('create-spool-form');
+    form.reset();
+    document.getElementById('create-spool-title').textContent = `Create Spool - Extruder ${channelNumber + 1}`;
+    document.getElementById('create-spool-channel').textContent = String(channelNumber + 1);
+    document.getElementById('create-spool-uid').textContent = formatUid(uid);
+    setCreateFormValues(createDefaultsFromChannel(channel));
+    setCreateFilamentFieldsLocked(true);
+    document.getElementById('create-spool-match-section').style.display = 'none';
+    createSpoolContext = { channel: channelNumber, uid, metadata: channel.rfid_data, matches: [], loading: true };
+    setCreateSpoolNotice('Checking Spoolman for the RFID and an exact filament match...');
+    setCreateSpoolLoading(true);
+    openModal('create-spool-modal');
+
+    try {
+        const [spools, filaments] = await Promise.all([
+            fetchSpoolmanAllSpools(),
+            fetchSpoolmanFilaments(),
+        ]);
+        ensureChannelUid(channelNumber, uid);
+        storeSpoolmanInventory(spools, false);
+        const owners = SM.findUidOwners(spools, uid);
+        if (owners.length > 0) {
+            rebuildFromCache();
+            closeModal('create-spool-modal');
+            createSpoolContext = null;
+            const ownerText = owners.map(owner => `#${owner.id}`).join(', ');
+            showStatus(`RFID ${formatUid(uid)} already belongs to Spoolman spool ${ownerText}`, 'error');
+            return;
+        }
+        const matches = SM.findMatchingFilaments(filaments, {
+            vendor: channel.rfid_data.vendor,
+            material: channel.rfid_data.type,
+            variant: channel.rfid_data.variant || channel.rfid_data.sub_type,
+            color: channel.rfid_data.color,
+        });
+        setCreateSpoolNotice('');
+        configureCreateFilamentMatches(matches);
+    } catch (err) {
+        setCreateSpoolNotice(`Cannot prepare spool creation: ${err.message}`, 'error');
+        setCreateSpoolLoading(false);
+        document.getElementById('create-spool-submit').disabled = true;
+    }
+}
+
+function closeCreateSpoolModal() {
+    if (createSpoolContext?.loading) return;
+    closeModal('create-spool-modal');
+    createSpoolContext = null;
+}
+
+async function handleCreateSpool(event) {
+    event.preventDefault();
+    if (!createSpoolContext || createSpoolContext.loading) return;
+    const context = createSpoolContext;
+    const form = event.currentTarget;
+    if (!form.reportValidity()) return;
+
+    const createdRecords = [];
+    let createdSpoolId = null;
+    setCreateSpoolLoading(true);
+    setCreateSpoolNotice('Rechecking Spoolman and the RFID before creating records...');
+
+    try {
+        ensureChannelUid(context.channel, context.uid);
+        const [spools, vendors, filaments] = await Promise.all([
+            fetchSpoolmanAllSpools(),
+            fetchSpoolmanVendors(),
+            fetchSpoolmanFilaments(),
+        ]);
+        storeSpoolmanInventory(spools, false);
+        ensureChannelUid(context.channel, context.uid);
+
+        const owners = SM.findUidOwners(spools, context.uid);
+        if (owners.length > 1) {
+            throw new Error(`RFID ${formatUid(context.uid)} is stored on multiple spools (${owners.map(owner => `#${owner.id}`).join(', ')}). Resolve the duplicate in Spoolman first.`);
+        }
+        if (owners.length === 1) {
+            const owner = owners[0];
+            setCreateSpoolNotice(`The RFID was linked to spool #${owner.id} while this dialog was open. Assigning that existing spool instead.`);
+            await executeSpoolAssignment(context.channel, owner, context.uid, SM.parseCardUids(owner));
+            closeModal('create-spool-modal');
+            createSpoolContext = null;
+            showStatus(`Existing spool #${owner.id} assigned to Extruder ${context.channel + 1}`, 'success');
+            return;
+        }
+
+        const values = readCreateFormValues();
+        const selectedId = Number(document.getElementById('create-spool-filament').value);
+        let filament = selectedId
+            ? filaments.find(item => Number(item.id) === selectedId)
+            : null;
+        if (selectedId && !filament) throw new Error(`Selected filament #${selectedId} no longer exists`);
+        if (filament && SM.findMatchingFilaments([filament], {
+            vendor: context.metadata.vendor,
+            material: context.metadata.type,
+            variant: context.metadata.variant || context.metadata.sub_type,
+            color: context.metadata.color,
+        }).length !== 1) {
+            throw new Error(`Selected filament #${selectedId} no longer matches the RFID metadata`);
+        }
+
+        if (!filament) {
+            const currentMatches = SM.findMatchingFilaments(filaments, values);
+            if (currentMatches.length === 1) {
+                filament = currentMatches[0];
+            } else if (currentMatches.length > 1) {
+                configureCreateFilamentMatches(currentMatches);
+                throw new Error('Multiple exact filament matches now exist. Select the intended record and submit again.');
+            } else {
+                const vendorName = SM.cleanText(values.vendor);
+                if (!vendorName) throw new Error('Vendor is required');
+                const orderedVendors = vendors.slice().sort((left, right) =>
+                    Number(!!(left.archived || left.is_archived)) - Number(!!(right.archived || right.is_archived)) ||
+                    Number(left.id) - Number(right.id));
+                let vendor = orderedVendors.find(item => SM.normalizeText(item.name) === SM.normalizeText(vendorName));
+                if (!vendor) {
+                    vendor = await spoolmanRequest('POST', '/v1/vendor', { body: { name: vendorName } });
+                    if (!vendor?.id) throw new Error('Spoolman did not return the created vendor ID');
+                    createdRecords.push(`vendor #${vendor.id}`);
+                }
+                const payload = SM.buildFilamentPayload(values, vendor.id);
+                filament = await spoolmanRequest('POST', '/v1/filament', { body: payload });
+                if (!filament?.id) throw new Error('Spoolman did not return the created filament ID');
+                createdRecords.push(`filament #${filament.id}`);
+            }
+        }
+
+        const spoolPayload = SM.buildSpoolPayload(filament.id, {
+            uid: context.uid,
+            net_weight: values.net_weight,
+            tare_weight: values.tare_weight,
+        });
+        const createdSpool = await spoolmanRequest('POST', '/v1/spool', { body: spoolPayload });
+        if (!createdSpool?.id) throw new Error('Spoolman did not return the created spool ID');
+        createdSpoolId = Number(createdSpool.id);
+        createdRecords.push(`spool #${createdSpoolId}`);
+
+        ensureChannelUid(context.channel, context.uid);
+        const postCreateSpools = await fetchSpoolmanAllSpools();
+        storeSpoolmanInventory(postCreateSpools, false);
+        const postCreateOwners = SM.findUidOwners(postCreateSpools, context.uid);
+        if (postCreateOwners.length !== 1 || Number(postCreateOwners[0].id) !== createdSpoolId) {
+            throw new Error('RFID ownership changed during creation; no assignment was attempted');
+        }
+        setCreateSpoolNotice(`Spool #${createdSpoolId} created. Assigning and verifying its RFID...`);
+        await executeSpoolAssignment(context.channel, createdSpool, context.uid, [context.uid]);
+        closeModal('create-spool-modal');
+        createSpoolContext = null;
+        showStatus(`Spool #${createdSpoolId} created and assigned to Extruder ${context.channel + 1}`, 'success');
+    } catch (err) {
+        const retained = createdRecords.length
+            ? ` Created records were retained for a safe retry: ${createdRecords.join(', ')}.`
+            : '';
+        const prefix = createdSpoolId != null ? `Spool #${createdSpoolId} was created, but assignment failed. ` : '';
+        const message = `${prefix}${err.message}.${retained}`.replace('..', '.');
+        setCreateSpoolNotice(message, 'error');
+        showStatus(`Create spool failed: ${err.message}`, 'error');
+    } finally {
+        if (createSpoolContext === context) setCreateSpoolLoading(false);
     }
 }
 
@@ -875,10 +1407,30 @@ function closeModal(id) {
 function initializeModals() {
     document.addEventListener('keydown', e => {
         if (e.key === 'Escape') {
+            if (document.getElementById('rfid-confirm-modal').style.display !== 'none') {
+                resolveRfidConfirmation(false);
+                return;
+            }
             closeModal('overwrite-modal'); closeModal('spoolman-modal');
             closeModal('mismatch-modal');
+            closeCreateSpoolModal();
         }
     });
+
+    document.getElementById('rfid-confirm-close').addEventListener('click', () => resolveRfidConfirmation(false));
+    document.getElementById('rfid-confirm-cancel').addEventListener('click', () => resolveRfidConfirmation(false));
+    document.getElementById('rfid-confirm-accept').addEventListener('click', () => resolveRfidConfirmation(true));
+    document.getElementById('rfid-confirm-modal').addEventListener('click', e => {
+        if (e.target.id === 'rfid-confirm-modal') resolveRfidConfirmation(false);
+    });
+
+    document.getElementById('create-spool-close').addEventListener('click', closeCreateSpoolModal);
+    document.getElementById('create-spool-cancel').addEventListener('click', closeCreateSpoolModal);
+    document.getElementById('create-spool-modal').addEventListener('click', e => {
+        if (e.target.id === 'create-spool-modal') closeCreateSpoolModal();
+    });
+    document.getElementById('create-spool-form').addEventListener('submit', handleCreateSpool);
+    document.getElementById('create-spool-filament').addEventListener('change', handleCreateFilamentSelection);
 
     document.getElementById('mismatch-close').addEventListener('click', () => closeModal('mismatch-modal'));
     document.getElementById('mismatch-cancel').addEventListener('click', () => closeModal('mismatch-modal'));

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/script.js
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/script.js
@@ -715,11 +715,19 @@ function createChannelCard(channel) {
         const owners = spoolmanInventoryLoaded
             ? SM.findUidOwners(spoolmanInventory, uid)
             : [];
-        if (!spoolmanInventoryLoaded || owners.length === 0) {
+        if (!spoolmanInventoryLoaded) {
             const createBtn = mkBtn('+ Create Spool', 'create-spool-btn', () => openCreateSpoolModal(channel.channel));
-            createBtn.disabled = !spoolmanInventoryLoaded;
-            if (createBtn.disabled) createBtn.title = 'Waiting for the Spoolman inventory';
+            createBtn.disabled = true;
+            createBtn.title = 'Waiting for the Spoolman inventory';
             actions.appendChild(createBtn);
+        } else if (owners.length === 0) {
+            const assignedSpool = spoolId != null ? spoolmanSpools.get(Number(spoolId)) : null;
+            if (assignedSpool) {
+                actions.appendChild(mkBtn('+ Add RFID', 'create-spool-btn', () =>
+                    assignSpoolToChannel(channel.channel, assignedSpool.id, false)));
+            } else {
+                actions.appendChild(mkBtn('+ Create Spool', 'create-spool-btn', () => openCreateSpoolModal(channel.channel)));
+            }
         }
     }
     if (spoolmanActive) actions.appendChild(mkBtn('⊕ Spool', '', () => openSpoolPicker(channel.channel)));
@@ -951,9 +959,13 @@ function renderSpoolList(filter) {
 }
 
 async function pickSpool(spoolId) {
-    if (spoolPickerChannel === null || spoolAssignmentBusy) return;
+    if (spoolPickerChannel === null) return;
+    await assignSpoolToChannel(spoolPickerChannel, spoolId, true);
+}
+
+async function assignSpoolToChannel(channel, spoolId, closePicker) {
+    if (spoolAssignmentBusy) return;
     spoolAssignmentBusy = true;
-    const channel = spoolPickerChannel;
     try {
         const uid = currentChannelUid(channel);
         const spools = await refreshSpoolmanInventory(false);
@@ -993,7 +1005,7 @@ async function pickSpool(spoolId) {
             ensureChannelUid(channel, uid);
         }
 
-        closeModal('spoolman-modal');
+        if (closePicker) closeModal('spoolman-modal');
         showStatus('Assigning spool…', 'info');
         await executeSpoolAssignment(channel, target, uid, previousTargetUids);
         showStatus(`Spool #${spoolId} assigned to Extruder ${channel + 1}`, 'success');

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/spoolman-utils.js
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/spoolman-utils.js
@@ -1,0 +1,323 @@
+(function (root, factory) {
+    'use strict';
+    const api = factory();
+    if (typeof module === 'object' && module.exports) {
+        module.exports = api;
+    } else {
+        root.SpoolmanUtils = api;
+    }
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    const MATERIAL_DENSITIES = Object.freeze({
+        PLA: 1.24,
+        PETG: 1.27,
+        ABS: 1.04,
+        ASA: 1.07,
+        TPU: 1.21,
+        NYLON: 1.12,
+        PA: 1.12,
+        PC: 1.19,
+        PVA: 1.19,
+        HIPS: 1.04,
+        PP: 0.90,
+    });
+
+    function cleanText(value) {
+        return value == null ? '' : String(value).trim();
+    }
+
+    function normalizeText(value) {
+        return cleanText(value).toLowerCase();
+    }
+
+    function finiteNumber(value) {
+        if (value === '' || value == null) return null;
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    function normalizeUid(value) {
+        if (Array.isArray(value) || ArrayBuffer.isView(value)) {
+            const bytes = Array.from(value);
+            if (bytes.length === 0 || bytes.every(byte => Number(byte) === 0)) return '';
+            if (bytes.some(byte => !Number.isInteger(Number(byte)) || Number(byte) < 0 || Number(byte) > 255)) return '';
+            return bytes.map(byte => Number(byte).toString(16).padStart(2, '0')).join('').toUpperCase();
+        }
+
+        let uid = cleanText(value).replace(/^0x/i, '').replace(/[\s:,.-]/g, '');
+        if (!uid || uid.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(uid) || /^0+$/.test(uid)) return '';
+        return uid.toUpperCase();
+    }
+
+    function decodeExtraString(value) {
+        let decoded = cleanText(value);
+        if (decoded.length >= 2 && decoded.startsWith('"') && decoded.endsWith('"')) {
+            try {
+                const parsed = JSON.parse(decoded);
+                if (typeof parsed === 'string') decoded = parsed;
+            } catch {
+                decoded = decoded.slice(1, -1);
+            }
+        }
+        return decoded;
+    }
+
+    function encodeExtraString(value) {
+        return JSON.stringify(cleanText(value));
+    }
+
+    function uniqueUids(values) {
+        const seen = new Set();
+        const result = [];
+        for (const value of values || []) {
+            const uid = normalizeUid(value);
+            if (uid && !seen.has(uid)) {
+                seen.add(uid);
+                result.push(uid);
+            }
+        }
+        return result;
+    }
+
+    function parseCardUids(spool) {
+        const raw = decodeExtraString(spool?.extra?.card_uids || '');
+        return uniqueUids(raw.split(','));
+    }
+
+    function encodeCardUids(values) {
+        return encodeExtraString(uniqueUids(values).join(','));
+    }
+
+    function parseVariant(filament) {
+        return decodeExtraString(filament?.extra?.variant || '');
+    }
+
+    function canonicalVariant(value) {
+        const variant = normalizeText(value);
+        return variant === 'basic' ? '' : variant;
+    }
+
+    function normalizeColor(value) {
+        const color = cleanText(value).replace(/^#/, '').toUpperCase();
+        return /^[0-9A-F]{6}$/.test(color) ? color : '';
+    }
+
+    function materialDensity(material, reportedDensity) {
+        const reported = finiteNumber(reportedDensity);
+        if (reported != null && reported >= 0.5 && reported <= 3.0) return reported;
+        return MATERIAL_DENSITIES[cleanText(material).toUpperCase()] || 1.24;
+    }
+
+    // Keep colour naming aligned with the SpoolLink companion app. It is only
+    // a friendly, editable default; exact matching always uses the RGB value.
+    function friendlyColorName(colorHex) {
+        const hex = normalizeColor(colorHex);
+        if (!hex) return null;
+        const red = parseInt(hex.slice(0, 2), 16) / 255;
+        const green = parseInt(hex.slice(2, 4), 16) / 255;
+        const blue = parseInt(hex.slice(4, 6), 16) / 255;
+        const max = Math.max(red, green, blue);
+        const min = Math.min(red, green, blue);
+        const delta = max - min;
+        const lightness = (max + min) / 2;
+
+        if (delta < 0.12) {
+            if (lightness > 0.85) return 'White';
+            if (lightness < 0.15) return 'Black';
+            return 'Gray';
+        }
+
+        const saturation = lightness > 0.5
+            ? delta / (2 - max - min)
+            : delta / (max + min);
+        if (saturation < 0.15) return lightness > 0.7 ? 'Silver' : 'Gray';
+
+        let hue;
+        if (max === red) {
+            hue = ((green - blue) / delta) % 6;
+            if (hue < 0) hue += 6;
+        } else if (max === green) {
+            hue = (blue - red) / delta + 2;
+        } else {
+            hue = (red - green) / delta + 4;
+        }
+        hue *= 60;
+
+        if (hue >= 10 && hue < 40 && lightness < 0.45) return 'Brown';
+        if (hue < 15) return 'Red';
+        if (hue < 40) return 'Orange';
+        if (hue < 65) return 'Yellow';
+        if (hue < 165) return 'Green';
+        if (hue < 195) return 'Cyan';
+        if (hue < 255) return 'Blue';
+        if (hue < 285) return 'Purple';
+        if (hue < 325) return 'Magenta';
+        if (hue < 345) return 'Pink';
+        return 'Red';
+    }
+
+    function defaultFilamentName(metadata) {
+        const parts = [
+            cleanText(metadata?.material),
+            cleanText(metadata?.variant),
+            friendlyColorName(metadata?.color) || normalizeColor(metadata?.color),
+        ].filter(Boolean);
+        const deduped = parts.filter((part, index) => index === 0 || normalizeText(part) !== normalizeText(parts[index - 1]));
+        return deduped.join(' ') || 'Custom Filament';
+    }
+
+    function isCreateEligible(channel) {
+        const metadata = channel?.rfid_data || {};
+        return !!(
+            normalizeUid(channel?.uid) &&
+            cleanText(metadata.vendor) &&
+            cleanText(metadata.type) &&
+            normalizeColor(metadata.color)
+        );
+    }
+
+    function findMatchingFilaments(filaments, metadata) {
+        const vendor = normalizeText(metadata?.vendor);
+        const material = normalizeText(metadata?.material || metadata?.type);
+        const variant = canonicalVariant(metadata?.variant || metadata?.sub_type);
+        const color = normalizeColor(metadata?.color);
+        if (!vendor || !material || !color) return [];
+
+        return (filaments || []).filter(filament => (
+            normalizeText(filament?.vendor?.name) === vendor &&
+            normalizeText(filament?.material) === material &&
+            canonicalVariant(parseVariant(filament)) === variant &&
+            normalizeColor(filament?.color_hex) === color
+        ));
+    }
+
+    function buildFilamentPayload(values, vendorId) {
+        const diameter = finiteNumber(values?.diameter);
+        const density = finiteNumber(values?.density);
+        const color = normalizeColor(values?.color);
+        const name = cleanText(values?.name);
+        const material = cleanText(values?.material);
+        if (!name) throw new Error('Filament name is required');
+        if (!material) throw new Error('Material is required');
+        if (!color) throw new Error('A valid six-digit colour is required');
+        if (diameter == null || diameter <= 0) throw new Error('Diameter must be greater than zero');
+        if (density == null || density <= 0) throw new Error('Density must be greater than zero');
+
+        const payload = {
+            name,
+            material,
+            color_hex: color,
+            diameter,
+            density,
+        };
+        if (Number.isInteger(Number(vendorId)) && Number(vendorId) > 0) payload.vendor_id = Number(vendorId);
+
+        const weight = finiteNumber(values?.net_weight);
+        const tare = finiteNumber(values?.tare_weight);
+        const nozzle = finiteNumber(values?.nozzle_temp);
+        const bed = finiteNumber(values?.bed_temp);
+        if (weight != null && weight > 0) payload.weight = weight;
+        if (tare != null && tare >= 0) payload.spool_weight = tare;
+        if (nozzle != null && nozzle > 0) payload.settings_extruder_temp = Math.round(nozzle);
+        if (bed != null && bed > 0) payload.settings_bed_temp = Math.round(bed);
+
+        const variant = cleanText(values?.variant);
+        if (variant) payload.extra = { variant: encodeExtraString(variant) };
+        return payload;
+    }
+
+    function buildSpoolPayload(filamentId, values) {
+        const id = Number(filamentId);
+        const uid = normalizeUid(values?.uid);
+        const netWeight = finiteNumber(values?.net_weight);
+        const tareWeight = finiteNumber(values?.tare_weight);
+        if (!Number.isInteger(id) || id <= 0) throw new Error('A valid filament is required');
+        if (!uid) throw new Error('A valid RFID UID is required');
+        if (netWeight == null || netWeight <= 0) throw new Error('Net weight must be greater than zero');
+
+        const payload = {
+            filament_id: id,
+            initial_weight: netWeight,
+            remaining_weight: netWeight,
+            extra: { card_uids: encodeCardUids([uid]) },
+        };
+        if (tareWeight != null && tareWeight >= 0) payload.spool_weight = tareWeight;
+        return payload;
+    }
+
+    function findUidOwners(spools, uidValue) {
+        const uid = normalizeUid(uidValue);
+        if (!uid) return [];
+        return (spools || []).filter(spool => parseCardUids(spool).includes(uid));
+    }
+
+    function assignmentDecision(targetSpool, uidValue, owners) {
+        const uid = normalizeUid(uidValue);
+        const targetUids = parseCardUids(targetSpool);
+        const targetId = Number(targetSpool?.id);
+        const otherOwnerIds = (owners || [])
+            .map(spool => Number(spool.id))
+            .filter(id => Number.isInteger(id) && id !== targetId);
+
+        let action = 'assign';
+        let confirmLabel = 'Assign Spool';
+        let requiresConfirmation = false;
+        if (uid && targetUids.includes(uid) && otherOwnerIds.length === 0) {
+            action = 'already_assigned';
+        } else if (uid && otherOwnerIds.length > 0) {
+            action = 'move';
+            confirmLabel = 'Move RFID';
+            requiresConfirmation = true;
+        } else if (uid && targetUids.length === 0) {
+            action = 'add_first';
+            confirmLabel = 'Assign RFID';
+        } else if (uid && targetUids.length === 1) {
+            action = 'add_second';
+            confirmLabel = 'Add Second RFID';
+            requiresConfirmation = true;
+        } else if (uid) {
+            action = 'add_extra';
+            confirmLabel = 'Add Another RFID';
+            requiresConfirmation = true;
+        }
+        return { action, requiresConfirmation, confirmLabel, targetUids, otherOwnerIds };
+    }
+
+    function verifyUidAssignment(spools, targetIdValue, uidValue, previousTargetUids) {
+        const targetId = Number(targetIdValue);
+        const uid = normalizeUid(uidValue);
+        const owners = findUidOwners(spools, uid);
+        const target = (spools || []).find(spool => Number(spool.id) === targetId);
+        const targetUids = parseCardUids(target);
+        const missingPrevious = uniqueUids(previousTargetUids)
+            .filter(previous => !targetUids.includes(previous));
+        return {
+            ok: !!target && owners.length === 1 && Number(owners[0].id) === targetId &&
+                targetUids.includes(uid) && missingPrevious.length === 0,
+            ownerIds: owners.map(spool => Number(spool.id)),
+            targetUids,
+            missingPrevious,
+        };
+    }
+
+    return Object.freeze({
+        assignmentDecision,
+        buildFilamentPayload,
+        buildSpoolPayload,
+        cleanText,
+        defaultFilamentName,
+        encodeCardUids,
+        findMatchingFilaments,
+        findUidOwners,
+        finiteNumber,
+        isCreateEligible,
+        materialDensity,
+        normalizeColor,
+        normalizeText,
+        normalizeUid,
+        parseCardUids,
+        parseVariant,
+        verifyUidAssignment,
+    });
+}));

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/style.css
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/style.css
@@ -290,6 +290,11 @@ header h1 {
 }
 
 .channel-action-btn:hover { border-color: var(--accent); }
+.channel-action-btn.create-spool-btn {
+    background: var(--accent);
+}
+.channel-action-btn.create-spool-btn:hover { background: var(--accent-hover); }
+.channel-action-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .channel-action-note { font-size: 12px; color: var(--muted); font-style: italic; }
 
 /* ── Modal overlay ───────────────────────────────────────────────────────── */
@@ -425,6 +430,12 @@ input[type="number"]:focus,
 select:focus {
     outline: none;
     border-color: var(--accent);
+}
+
+input:disabled,
+select:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
 }
 
 input[type="color"] {
@@ -787,6 +798,17 @@ input[type="checkbox"] {
     font-family: monospace;
 }
 
+.spoolman-rfid-count {
+    display: inline-block;
+    margin-top: 3px;
+    padding: 1px 5px;
+    border-radius: 999px;
+    background: var(--border);
+    color: var(--muted);
+    font-size: 10px;
+    white-space: nowrap;
+}
+
 .spoolman-empty,
 .spoolman-loading {
     text-align: center;
@@ -796,6 +818,80 @@ input[type="checkbox"] {
 }
 
 .spool-remaining { color: var(--success); font-weight: 600; }
+
+/* Create-spool and RFID confirmation dialogs */
+.create-spool-dialog { width: 720px; }
+.confirm-dialog { width: 520px; }
+
+.create-spool-source {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.create-spool-source > div {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 9px 12px;
+    border-radius: 6px;
+    background: var(--item);
+}
+
+.create-spool-source span,
+.create-spool-section-title {
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}
+
+.create-spool-source strong {
+    font-family: monospace;
+    font-size: 13px;
+}
+
+.create-spool-section-title {
+    margin: 16px 0 8px;
+}
+
+.create-spool-notice {
+    margin-bottom: 16px;
+    padding: 10px 12px;
+    border: 1px solid rgba(255, 152, 0, 0.4);
+    border-radius: 6px;
+    background: rgba(255, 152, 0, 0.12);
+    color: var(--warning);
+    font-size: 13px;
+}
+
+.create-spool-notice.error {
+    border-color: rgba(244, 67, 54, 0.45);
+    background: rgba(244, 67, 54, 0.12);
+    color: #ff8a80;
+}
+
+.form-help {
+    margin: 5px 0 0;
+    color: var(--muted);
+    font-size: 11px;
+    line-height: 1.4;
+}
+
+.confirm-content {
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.confirm-content p { margin: 0 0 10px; }
+.confirm-content p:last-child { margin-bottom: 0; }
+
+@media (max-width: 560px) {
+    .create-spool-source { grid-template-columns: 1fr; }
+}
 
 .info-popover {
     position: fixed;

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/style.css
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/style.css
@@ -286,6 +286,11 @@ header h1 {
 }
 
 .channel-action-btn:hover { border-color: var(--accent); }
+.channel-action-btn.create-spool-btn {
+    background: var(--accent);
+}
+.channel-action-btn.create-spool-btn:hover { background: var(--accent-hover); }
+.channel-action-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .channel-action-note { font-size: 12px; color: var(--muted); font-style: italic; }
 
 /* ── Modal overlay ───────────────────────────────────────────────────────── */
@@ -421,6 +426,12 @@ input[type="number"]:focus,
 select:focus {
     outline: none;
     border-color: var(--accent);
+}
+
+input:disabled,
+select:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
 }
 
 input[type="color"] {
@@ -783,6 +794,17 @@ input[type="checkbox"] {
     font-family: monospace;
 }
 
+.spoolman-rfid-count {
+    display: inline-block;
+    margin-top: 3px;
+    padding: 1px 5px;
+    border-radius: 999px;
+    background: var(--border);
+    color: var(--muted);
+    font-size: 10px;
+    white-space: nowrap;
+}
+
 .spoolman-empty,
 .spoolman-loading {
     text-align: center;
@@ -792,6 +814,80 @@ input[type="checkbox"] {
 }
 
 .spool-remaining { color: var(--success); font-weight: 600; }
+
+/* Create-spool and RFID confirmation dialogs */
+.create-spool-dialog { width: 720px; }
+.confirm-dialog { width: 520px; }
+
+.create-spool-source {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.create-spool-source > div {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 9px 12px;
+    border-radius: 6px;
+    background: var(--item);
+}
+
+.create-spool-source span,
+.create-spool-section-title {
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}
+
+.create-spool-source strong {
+    font-family: monospace;
+    font-size: 13px;
+}
+
+.create-spool-section-title {
+    margin: 16px 0 8px;
+}
+
+.create-spool-notice {
+    margin-bottom: 16px;
+    padding: 10px 12px;
+    border: 1px solid rgba(255, 152, 0, 0.4);
+    border-radius: 6px;
+    background: rgba(255, 152, 0, 0.12);
+    color: var(--warning);
+    font-size: 13px;
+}
+
+.create-spool-notice.error {
+    border-color: rgba(244, 67, 54, 0.45);
+    background: rgba(244, 67, 54, 0.12);
+    color: #ff8a80;
+}
+
+.form-help {
+    margin: 5px 0 0;
+    color: var(--muted);
+    font-size: 11px;
+    line-height: 1.4;
+}
+
+.confirm-content {
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.confirm-content p { margin: 0 0 10px; }
+.confirm-content p:last-child { margin-bottom: 0; }
+
+@media (max-width: 560px) {
+    .create-spool-source { grid-template-columns: 1fr; }
+}
 
 .info-popover {
     position: fixed;

--- a/overlays/firmware-extended/68-app-filament-ui/test/cache-policy.test.js
+++ b/overlays/firmware-extended/68-app-filament-ui/test/cache-policy.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const overlayRoot = path.join(__dirname, '..', 'root');
+
+test('Filament Manager assets bypass old browser cache entries', () => {
+    const html = fs.readFileSync(path.join(
+        overlayRoot,
+        'usr/local/filament-ui/html/index.html'
+    ), 'utf8');
+
+    assert.match(html, /href="style\.css\?v=2"/);
+    assert.match(html, /src="spoolman-utils\.js\?v=2"/);
+    assert.match(html, /src="script\.js\?v=2"/);
+});
+
+test('Filament Manager responses are not stored by browsers', () => {
+    const nginx = fs.readFileSync(path.join(
+        overlayRoot,
+        'etc/nginx/fluidd.d/filament.conf'
+    ), 'utf8');
+
+    assert.match(
+        nginx,
+        /add_header Cache-Control "no-store, no-cache, must-revalidate" always;/
+    );
+});

--- a/overlays/firmware-extended/68-app-filament-ui/test/spoolman-utils.test.js
+++ b/overlays/firmware-extended/68-app-filament-ui/test/spoolman-utils.test.js
@@ -1,0 +1,162 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const SM = require('../root/usr/local/filament-ui/html/spoolman-utils.js');
+
+function spool(id, uids, filament = {}) {
+    return {
+        id,
+        extra: { card_uids: SM.encodeCardUids(uids) },
+        filament: {
+            name: `Filament ${id}`,
+            material: 'PLA',
+            color_hex: '112233',
+            vendor: { name: 'Example' },
+            ...filament,
+        },
+    };
+}
+
+test('normalizes U1 byte-array and text UIDs', () => {
+    assert.equal(SM.normalizeUid([0xA1, 0xB2, 0xC3, 0xD4]), 'A1B2C3D4');
+    assert.equal(SM.normalizeUid('a1:b2:c3:d4'), 'A1B2C3D4');
+    assert.equal(SM.normalizeUid([0, 0, 0, 0]), '');
+    assert.equal(SM.normalizeUid('not-a-uid'), '');
+});
+
+test('round-trips JSON-encoded, comma-separated card_uids', () => {
+    const encoded = SM.encodeCardUids(['aabbccdd', '11223344', 'AABBCCDD']);
+    assert.equal(encoded, '"AABBCCDD,11223344"');
+    assert.deepEqual(SM.parseCardUids({ extra: { card_uids: encoded } }), [
+        'AABBCCDD',
+        '11223344',
+    ]);
+});
+
+test('treats blank and Basic variants as the same exact match', () => {
+    const filaments = [
+        {
+            id: 18,
+            vendor: { name: 'Bambu Lab' },
+            material: 'PLA',
+            color_hex: '9d2235',
+            extra: { variant: '""' },
+        },
+        {
+            id: 19,
+            vendor: { name: 'Bambu Lab' },
+            material: 'PLA',
+            color_hex: 'FFFFFF',
+            extra: { variant: '"Basic"' },
+        },
+    ];
+    const matches = SM.findMatchingFilaments(filaments, {
+        vendor: 'bambu lab',
+        material: 'pla',
+        variant: 'Basic',
+        color: '#9D2235',
+    });
+    assert.deepEqual(matches.map(item => item.id), [18]);
+});
+
+test('requires metadata-bearing RFID tags for spool creation', () => {
+    const complete = {
+        uid: [0x01, 0x02, 0x03, 0x04],
+        rfid_data: { vendor: 'Bambu Lab', type: 'PLA', color: '9D2235' },
+    };
+    assert.equal(SM.isCreateEligible(complete), true);
+    assert.equal(SM.isCreateEligible({ ...complete, rfid_data: { type: 'PLA', color: '9D2235' } }), false);
+    assert.equal(SM.isCreateEligible({ ...complete, uid: [0, 0, 0, 0] }), false);
+});
+
+test('builds standard Spoolman filament and spool payloads', () => {
+    const filament = SM.buildFilamentPayload({
+        name: 'PLA Basic Red',
+        material: 'PLA',
+        variant: 'Basic',
+        color: '#9d2235',
+        diameter: '1.75',
+        density: '1.24',
+        net_weight: '1000',
+        tare_weight: '250',
+        nozzle_temp: '230',
+        bed_temp: '55',
+    }, 7);
+    assert.deepEqual(filament, {
+        name: 'PLA Basic Red',
+        material: 'PLA',
+        color_hex: '9D2235',
+        diameter: 1.75,
+        density: 1.24,
+        vendor_id: 7,
+        weight: 1000,
+        spool_weight: 250,
+        settings_extruder_temp: 230,
+        settings_bed_temp: 55,
+        extra: { variant: '"Basic"' },
+    });
+
+    const createdSpool = SM.buildSpoolPayload(18, {
+        uid: 'a1b2c3d4',
+        net_weight: '1000',
+        tare_weight: '250',
+    });
+    assert.deepEqual(createdSpool, {
+        filament_id: 18,
+        initial_weight: 1000,
+        remaining_weight: 1000,
+        spool_weight: 250,
+        extra: { card_uids: '"A1B2C3D4"' },
+    });
+});
+
+test('classifies first, second, extra, and moved RFID assignments', () => {
+    const first = SM.assignmentDecision(spool(1, []), 'AABBCCDD', []);
+    const second = SM.assignmentDecision(spool(1, ['01020304']), 'AABBCCDD', []);
+    const extra = SM.assignmentDecision(spool(1, ['01020304', '05060708']), 'AABBCCDD', []);
+    const move = SM.assignmentDecision(
+        spool(1, ['01020304']),
+        'AABBCCDD',
+        [spool(2, ['AABBCCDD'])],
+    );
+    const existing = SM.assignmentDecision(spool(1, ['AABBCCDD']), 'AABBCCDD', [spool(1, ['AABBCCDD'])]);
+
+    assert.equal(first.action, 'add_first');
+    assert.equal(first.requiresConfirmation, false);
+    assert.equal(second.action, 'add_second');
+    assert.equal(second.confirmLabel, 'Add Second RFID');
+    assert.equal(extra.action, 'add_extra');
+    assert.equal(extra.confirmLabel, 'Add Another RFID');
+    assert.equal(move.action, 'move');
+    assert.equal(move.confirmLabel, 'Move RFID');
+    assert.equal(existing.action, 'already_assigned');
+    assert.equal(existing.requiresConfirmation, false);
+});
+
+test('verifies exclusive ownership while preserving both existing target UIDs', () => {
+    const prior = ['01020304', '05060708'];
+    const success = SM.verifyUidAssignment([
+        spool(1, [...prior, 'AABBCCDD']),
+        spool(2, []),
+    ], 1, 'AABBCCDD', prior);
+    assert.equal(success.ok, true);
+
+    const duplicate = SM.verifyUidAssignment([
+        spool(1, [...prior, 'AABBCCDD']),
+        spool(2, ['AABBCCDD']),
+    ], 1, 'AABBCCDD', prior);
+    assert.equal(duplicate.ok, false);
+    assert.deepEqual(duplicate.ownerIds, [1, 2]);
+
+    const lostPriorUid = SM.verifyUidAssignment([
+        spool(1, ['01020304', 'AABBCCDD']),
+    ], 1, 'AABBCCDD', prior);
+    assert.equal(lostPriorUid.ok, false);
+    assert.deepEqual(lostPriorUid.missingPrevious, ['05060708']);
+});
+
+test('uses material density fallback and an editable friendly name', () => {
+    assert.equal(SM.materialDensity('PETG', 0), 1.27);
+    assert.equal(SM.defaultFilamentName({ material: 'PLA', variant: 'Basic', color: '9D2235' }), 'PLA Basic Red');
+});

--- a/scripts/check_line_endings.py
+++ b/scripts/check_line_endings.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Reject carriage returns in firmware source and packaged Linux scripts."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def git_files(directory: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        cwd=directory,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return [directory / os.fsdecode(name) for name in result.stdout.split(b"\0") if name]
+
+
+def source_files() -> list[tuple[Path, bool]]:
+    files = [(path, False) for path in git_files(REPO_ROOT)]
+    result = subprocess.run(
+        ["git", "submodule", "status", "--recursive"],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    for line in result.stdout.splitlines():
+        if not line or line[0] == "-":
+            continue
+        fields = line[1:].strip().split(maxsplit=2)
+        if len(fields) < 2:
+            continue
+        submodule = REPO_ROOT / fields[1]
+        files.extend((path, True) for path in git_files(submodule))
+    return files
+
+
+def is_utf8_text(data: bytes) -> bool:
+    if b"\0" in data:
+        return False
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def is_firmware_script(path: Path, data: bytes) -> bool:
+    relative = path.relative_to(REPO_ROOT)
+    if data.startswith(b"#!") or path.name == "Makefile" or path.suffix in {".mk", ".sh"}:
+        return True
+    if relative.parts[0] != "overlays":
+        return False
+    if "scripts" in relative.parts or "pre-scripts" in relative.parts:
+        return True
+    try:
+        root_index = relative.parts.index("root")
+    except ValueError:
+        return data.startswith(b"#!")
+    root_path = relative.parts[root_index + 1 :]
+    return root_path[:2] == ("etc", "init.d") or data.startswith(b"#!")
+
+
+def check_source() -> int:
+    bad: list[Path] = []
+    checked = 0
+    for path, scan_all_text in source_files():
+        if not path.is_file() or path.is_symlink():
+            continue
+        data = path.read_bytes()
+        if not is_utf8_text(data) or (not scan_all_text and not is_firmware_script(path, data)):
+            continue
+        checked += 1
+        if b"\r" in data:
+            bad.append(path.relative_to(REPO_ROOT))
+
+    if bad:
+        print("Error: carriage returns found in firmware script sources:", file=sys.stderr)
+        for path in bad:
+            print(f"  {path.as_posix()}", file=sys.stderr)
+        print("Normalize these files to LF before building.", file=sys.stderr)
+        print("On Windows, set core.autocrlf=false in this repository and its submodules.", file=sys.stderr)
+        return 1
+
+    print(f"Line-ending check passed for {checked} firmware script sources.")
+    return 0
+
+
+def rootfs_script_files(rootfs: Path) -> list[Path]:
+    candidates: set[Path] = set()
+    init_dir = rootfs / "etc" / "init.d"
+    if init_dir.is_dir():
+        candidates.update(path for path in init_dir.iterdir() if path.is_file() and not path.is_symlink())
+
+    for directory, dirnames, filenames in os.walk(rootfs, followlinks=False):
+        current = Path(directory)
+        dirnames[:] = [name for name in dirnames if not (current / name).is_symlink()]
+        for name in filenames:
+            path = current / name
+            if path.is_symlink() or not path.is_file():
+                continue
+            try:
+                with path.open("rb") as handle:
+                    if handle.read(2) == b"#!":
+                        candidates.add(path)
+            except OSError as error:
+                print(f"Error reading {path}: {error}", file=sys.stderr)
+                raise
+    return sorted(candidates)
+
+
+def check_rootfs(rootfs: Path) -> int:
+    if not rootfs.is_dir():
+        print(f"Error: root filesystem directory does not exist: {rootfs}", file=sys.stderr)
+        return 2
+
+    scripts = rootfs_script_files(rootfs)
+    bad = [path.relative_to(rootfs) for path in scripts if b"\r" in path.read_bytes()]
+    if bad:
+        print("Error: carriage returns found in packaged Linux scripts:", file=sys.stderr)
+        for path in bad:
+            print(f"  /{path.as_posix()}", file=sys.stderr)
+        print("Refusing to package a root filesystem with invalid Linux script line endings.", file=sys.stderr)
+        return 1
+
+    print(f"Line-ending check passed for {len(scripts)} packaged Linux scripts.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rootfs", type=Path, help="check init and shebang scripts in an assembled root filesystem")
+    args = parser.parse_args()
+    return check_rootfs(args.rootfs.resolve()) if args.rootfs else check_source()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/create_firmware.sh
+++ b/scripts/create_firmware.sh
@@ -116,6 +116,9 @@ if [[ -z "$CI" ]]; then
   rm -rf "$ROOTFS_DIR/cache"
 fi
 
+echo ">> Checking Linux script line endings..."
+python3 "$ROOT_DIR/scripts/check_line_endings.py" --rootfs "$ROOTFS_DIR"
+
 echo ">> Checking for non-ARM binaries in rootfs..."
 if FILES=$(find "$ROOTFS_DIR" -type f -exec file {} + | grep "ELF" | grep -v "ARM"); then
   echo "!! Error: Found non-ARM binaries in the rootfs:"

--- a/scripts/create_firmware.sh
+++ b/scripts/create_firmware.sh
@@ -113,6 +113,9 @@ if [[ -z "$CI" ]]; then
   rm -rf "$ROOTFS_DIR/cache"
 fi
 
+echo ">> Checking Linux script line endings..."
+python3 "$ROOT_DIR/scripts/check_line_endings.py" --rootfs "$ROOTFS_DIR"
+
 echo ">> Checking for non-ARM binaries in rootfs..."
 if FILES=$(find "$ROOTFS_DIR" -type f -exec file {} + | grep "ELF" | grep -v "ARM"); then
   echo "!! Error: Found non-ARM binaries in the rootfs:"

--- a/scripts/test_check_line_endings.py
+++ b/scripts/test_check_line_endings.py
@@ -1,0 +1,35 @@
+from contextlib import redirect_stderr, redirect_stdout
+import io
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.check_line_endings import check_rootfs
+
+
+class RootfsLineEndingTests(unittest.TestCase):
+    def run_check(self, files: dict[str, bytes]) -> int:
+        with tempfile.TemporaryDirectory() as directory:
+            rootfs = Path(directory)
+            for relative_path, data in files.items():
+                path = rootfs / relative_path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(data)
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                return check_rootfs(rootfs)
+
+    def test_accepts_lf_scripts(self) -> None:
+        self.assertEqual(self.run_check({"etc/init.d/S99good": b"#!/bin/sh\necho good\n"}), 0)
+
+    def test_rejects_crlf_init_script(self) -> None:
+        self.assertEqual(self.run_check({"etc/init.d/S99bad": b"#!/bin/sh\r\necho bad\r\n"}), 1)
+
+    def test_rejects_crlf_shebang_script_outside_init(self) -> None:
+        self.assertEqual(self.run_check({"usr/local/bin/bad": b"#!/bin/sh\r\necho bad\r\n"}), 1)
+
+    def test_ignores_unrelated_crlf_data(self) -> None:
+        self.assertEqual(self.run_check({"usr/share/data.txt": b"not a script\r\n"}), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add an explicit Filament Manager action to create and assign a Spoolman spool
  from the RFID metadata currently read by a U1 channel.
- Preserve existing RFID ownership and support attaching the second physical
  tag to the same spool without losing the first UID.
- Reject duplicate ownership, verify writes, and keep the implementation in the
  existing static Filament Manager SPA and Spoolman REST API.
- Add a CRLF build guard for Linux startup scripts after physical recovery
  testing exposed a Windows-checkout failure mode.
- Prevent stale Filament Manager assets with a no-store cache policy and
  versioned CSS/JavaScript URLs.

## Reviewer notes

- This extends the existing static Filament Manager SPA and Moonraker Spoolman
  proxy; it adds no daemon, backend endpoint, or Spoolman schema migration.
- RFID UIDs remain in Spoolman's existing `extra.card_uids` field. Adding the
  second physical tag preserves the first UID.
- Cross-spool duplicate ownership is rejected, and RFID writes are read back
  and verified before the operation is reported as successful.

## Screenshots

Representative data is used in these captures. The first-tag creation and
second-tag attachment flows were also physically tested on a Snapmaker U1.

**Create action for an unassigned RFID tag**

<img width="966" height="966" alt="Filament Manager showing Create Spool for an unassigned RFID tag in extruder 3" src="https://github.com/user-attachments/assets/943d932d-2f54-49a5-b714-5f2c92e3d8dc" />

**Prefilled creation dialog using an exact Spoolman filament match**

<img width="966" height="966" alt="Create Spool dialog prefilled from RFID metadata" src="https://github.com/user-attachments/assets/ae19ebbd-9bfa-4b11-b3d3-01e5d2cd8d4d" />

**Attach the spool's second physical RFID tag**

<img width="966" height="966" alt="Filament Manager showing Add RFID for the second physical tag" src="https://github.com/user-attachments/assets/7a8539b8-7bc7-491d-92e8-4cf2751dd7cc" />

## Testing

- Physically tested first-tag spool creation on a Snapmaker U1.
- Physically tested attaching the second RFID tag to an existing spool.
- Confirmed normal touchscreen startup, Moonraker/Klipper readiness, all five
  MCUs, RFID discovery, and print start on the guarded firmware.
- Built from an LF-clean WSL2 checkout under `~/src`; 110 source files and 279
  packaged Linux scripts passed the line-ending guard.
- Filament Manager Node suite: 10 tests passed.
- Full local extended firmware build and assembled-rootfs inspection passed.
- Native ARM64 pull-request build passed in
  [GitHub Actions run 31437680324](https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/actions/runs/31437680324).
- The authoritative CI artifact was flashed and validated on the printer.

Related: #617

## AI assistance

This contribution was developed with AI assistance using OpenAI Codex. I
reviewed the implementation, verified the generated diff, and performed the
physical printer and RFID tests described above.
