### PR TITLE
chore(fluidd): Updating version and hash to fluidd v1.37.4

### DIFF
--- a/overlays/firmware-extended/62-app-fluidd/pre-scripts/01-install-fluidd.sh
+++ b/overlays/firmware-extended/62-app-fluidd/pre-scripts/01-install-fluidd.sh
@@ -7,9 +7,9 @@ fi
 
 set -eo pipefail
 
-VERSION=v1.37.2
+VERSION=v1.37.4
 URL=https://github.com/fluidd-core/fluidd/releases/download/$VERSION/fluidd.zip
-SHA256=e42d4e8b14a3a0b20573485c882cc4dcfac33d9fbd946c8803a942be282e2b6e
+SHA256=df4502c53e25e8b030e1fc5314f5eccac3de1872fce0216092ea94178432423e
 FILENAME=fluidd-$VERSION.zip
 
 rm -rf "$ROOTFS_DIR/home/lava/fluidd"


### PR DESCRIPTION
This PR updates fluidd version and hash to use version 1.37.4 that was released on August 11 2026.