### PR TITLE
Harden SpoolLink same-UID recovery

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -25,6 +25,12 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 
+    - name: Test SpoolLink
+      run: >-
+        python3 -m unittest discover
+        overlays/firmware-extended/38-feature-spoollink/test
+        -p 'test_*.py'
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 

--- a/docs/design/filament_detect.md
+++ b/docs/design/filament_detect.md
@@ -104,6 +104,18 @@ The endpoint has three modes determined by the filament fields present in `info`
 
 `CARD_UID` and `CARD_TYPE` are both popped before `has_params` is computed, so they never contribute to `OFFICIAL`. `CARD_TYPE` is populated automatically on hardware reads (`NTAG` via `filament_protocol_ndef`, `M1` via `filament_protocol`).
 
+### Feederless channel lifecycle
+
+A channel listed in SpoolLink's `external_channels` configuration relies on the
+external integration for UID presence. The integration must send a stable,
+non-empty `CARD_UID` while a spool is selected, send the replacement UID when
+the slot changes, and use the clear mode when no spool is selected. An empty UID
+releases the current spool assignment even during automatic loading.
+
+The endpoint shape does not change for feederless channels. Configuration is
+explicit because built-in OpenRFID and community readers use the same endpoint,
+so the request itself does not identify the reader source.
+
 ## openrfid Integration
 
 `openrfid_u1_base.cfg` registers two webhook exporters that drive `filament_detect/set` automatically:

--- a/docs/design/spoolman.md
+++ b/docs/design/spoolman.md
@@ -167,6 +167,25 @@ it does not maintain its own WebSocket connection.
 7. Klipper stores the metadata in `print_task_config` and notifies subscribers.
    `AFC_lane.get_status()` surfaces `spool_id` to Fluidd/Mainsail.
 
+### Detection-event recovery
+
+When `filament_detect.info[channel]` exposes `CARD_EVENT_TIME`, SpoolLink
+treats each increasing value as the primary evidence that the channel record
+was rewritten. A non-empty UID is resolved even when the UID and filament
+metadata are unchanged. This repairs the spool-ID loss caused by a successful
+same-card rescan without inferring the event from metadata or reader timing.
+
+The UID and `CARD_EVENT_TIME` form the generation for an automatic resolution.
+SpoolLink runs one resolution task per channel, queues the newest generation,
+and verifies both values again before applying the result. An empty or changed
+UID, an unqualified manual clear, feeder removal, or a Klippy disconnect
+invalidates pending work. While a known same-UID spool is resolving, the
+active-spool hold prevents an intermediate `None` from reaching Spoolman.
+
+Reader-state, metadata, and sensor evidence remain as compatibility fallbacks
+when the running firmware does not expose `CARD_EVENT_TIME`. The guarded
+empty-UID automatic-load recovery is separate because it has no UID to resolve.
+
 ## Feederless external channels
 
 The optional `[spoollink] external_channels` setting accepts a comma-separated
@@ -174,11 +193,12 @@ list of zero-based channels from `0` through `3`. The firmware configuration
 hook copies `[spoolman] external_channels` from `extended2.cfg` into the
 generated Moonraker section. The default is an empty list.
 
-For a configured channel, a changed external UID opens the same five-second
-refresh window used by reader and metadata evidence. A spool-ID clear during
-that window can re-resolve the same UID without requiring side-feeder
-eligibility. A feeder eligible-to-ineligible transition retains the known spool
-only while the current non-empty UID is resolved and still matches that spool.
+For a configured channel, an advancing `CARD_EVENT_TIME` re-resolves the
+current non-empty UID without requiring side-feeder eligibility. A changed UID
+also opens the five-second compatibility window used when the event field is
+unavailable. A feeder eligible-to-ineligible transition retains the known
+spool only while the current non-empty UID is resolved and still matches that
+spool.
 
 The component does not infer external channels from feeder state. Empty UIDs,
 different UIDs, unresolved UIDs, expired refresh windows, and Klippy disconnects

--- a/docs/design/spoolman.md
+++ b/docs/design/spoolman.md
@@ -167,3 +167,20 @@ it does not maintain its own WebSocket connection.
 7. Klipper stores the metadata in `print_task_config` and notifies subscribers.
    `AFC_lane.get_status()` surfaces `spool_id` to Fluidd/Mainsail.
 
+## Feederless external channels
+
+The optional `[spoollink] external_channels` setting accepts a comma-separated
+list of zero-based channels from `0` through `3`. The firmware configuration
+hook copies `[spoolman] external_channels` from `extended2.cfg` into the
+generated Moonraker section. The default is an empty list.
+
+For a configured channel, a changed external UID opens the same five-second
+refresh window used by reader and metadata evidence. A spool-ID clear during
+that window can re-resolve the same UID without requiring side-feeder
+eligibility. A feeder eligible-to-ineligible transition retains the known spool
+only while the current non-empty UID is resolved and still matches that spool.
+
+The component does not infer external channels from feeder state. Empty UIDs,
+different UIDs, unresolved UIDs, expired refresh windows, and Klippy disconnects
+release the previous assignment. Empty-UID automatic-load recovery remains
+restricted to normal feeder channels.

--- a/docs/spoolman.md
+++ b/docs/spoolman.md
@@ -82,6 +82,39 @@ when a tag can't be parsed:
 Hardware and setup details for both readers are in
 [RFID Format & Reader Design](design/rfid.md#readers).
 
+### Feederless external channels
+
+An external filament system can feed a toolhead without using the matching U1
+side feeder. SpoolLink cannot identify this arrangement from feeder status
+alone because an empty or disconnected side feeder reports the same state.
+
+Back up `/oem/printer_data/config/extended/extended2.cfg`, then add
+`external_channels` under its existing `[spoolman]` section. Channel numbers
+are zero-based and may be comma-separated:
+
+```ini
+external_channels: 3
+```
+
+Channel `3` corresponds to toolhead 4. Do not include channels that use their
+normal side feeders. Reboot after changing the setting so the Moonraker config
+is regenerated.
+
+For each configured channel, the external integration must:
+
+- report a stable, non-empty `CARD_UID` whenever a spool is selected;
+- report the new UID when the external slot changes; and
+- clear the channel through `filament_detect/set` when no spool is selected.
+
+An empty UID always releases a feederless channel. SpoolLink does not apply its
+empty-UID automatic-load fallback to these channels.
+
+## Active spool ownership
+
+The spool resolved for the selected toolhead channel is authoritative. If a
+client manually changes Moonraker's active spool while that channel remains
+resolved, SpoolLink sets the channel's spool active again on its next sync.
+
 ## GCode Commands
 
 ### `SET_SPOOL_ID`

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
@@ -41,4 +41,6 @@ cloud: none
 
 # Spoolman server URL for filament tracking; managed via firmware-config.
 # Example: host: http://192.168.1.100:7912
+# Zero-based channels fed by an external system without a side feeder.
+# Example: external_channels: 3
 [spoolman]

--- a/overlays/firmware-extended/38-feature-spoollink/root/etc/hooks/moonraker.d/10-spoollink.sh
+++ b/overlays/firmware-extended/38-feature-spoollink/root/etc/hooks/moonraker.d/10-spoollink.sh
@@ -1,17 +1,22 @@
 # Render the Moonraker `[spoolman]` and `[spoollink]` config from the Spoolman
 # configuration.
 #
-# `[spoolman] host` in `extended2.cfg` is the single source of truth. When a host
+# The `[spoolman]` section in `extended2.cfg` is the source of truth. When a host
 # is configured, generate the Moonraker `[spoolman]` block (built-in usage
 # tracking) and the `[spoollink]` block (the SpoolLink component that bridges
 # Spoolman to the AFC/RFID stack) into the extended config directory pointing at
-# it; otherwise remove the generated config.
+# it; otherwise remove the generated config. Optional external channels are
+# copied into the SpoolLink block.
 if [ "$1" = start ]; then
     EXTENDED_CFG="/oem/printer_data/config/extended/extended2.cfg"
     MOONRAKER_CFG="/oem/printer_data/config/extended/moonraker/spoollink.cfg"
     CACHE_DIR="/oem/printer_data/config/extended/spoollink"
 
     SPOOLMAN_HOST=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" spoolman host "" 2>/dev/null)
+    EXTERNAL_CHANNELS=$(
+        /usr/local/bin/extended-config.py get \
+            "$EXTENDED_CFG" spoolman external_channels "" 2>/dev/null
+    )
     if [ -n "$SPOOLMAN_HOST" ]; then
         mkdir -p "$(dirname "$MOONRAKER_CFG")" "$CACHE_DIR"
         chown lava:lava "$CACHE_DIR"
@@ -26,6 +31,7 @@ sync_rate: 5
 [spoollink]
 server: $SPOOLMAN_HOST
 cache_dir: $CACHE_DIR
+external_channels: $EXTERNAL_CHANNELS
 EOF
         chown lava:lava "$MOONRAKER_CFG"
     else

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
@@ -14,7 +14,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 if TYPE_CHECKING:
     from ..confighelper import ConfigHelper
@@ -55,6 +55,15 @@ class SpoolLink:
             url = "http://" + url
         self._spoolman_url = url
         self._cache_dir: Optional[str] = config.get("cache_dir", None)
+        configured_channels = config.getintlist(
+            "external_channels", [], separator=",")
+        invalid_channels = sorted({
+            ch for ch in configured_channels if ch < 0 or ch > 3})
+        if invalid_channels:
+            raise config.error(
+                "[spoollink] external_channels must contain only channel "
+                f"numbers from 0 to 3; invalid: {invalid_channels}")
+        self._external_channels: Set[int] = set(configured_channels)
         self.http_client: HttpClient = self.server.lookup_component("http_client")
         self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
 
@@ -91,8 +100,10 @@ class SpoolLink:
 
     async def component_init(self) -> None:
         logging.info(
-            "spoollink starting (spoolman: %s, cache: %s)",
-            self._spoolman_url, self._cache_dir or "disabled")
+            "spoollink starting (spoolman: %s, cache: %s, "
+            "external channels: %s)",
+            self._spoolman_url, self._cache_dir or "disabled",
+            sorted(self._external_channels) or "none")
         await self._ensure_fields()
 
     # -- Klippy lifecycle ---------------------------------------------------
@@ -229,17 +240,45 @@ class SpoolLink:
                 self._feeder_load_states[ch] = (
                     state.get("channel_state"),
                     state.get("channel_action_state"))
+                module_exist = bool(state.get("module_exist"))
+                filament_detected = bool(state.get("filament_detected"))
+                disable_auto = bool(state.get("disable_auto"))
                 eligible = bool(
-                    state.get("module_exist")
-                    and state.get("filament_detected")
-                    and not state.get("disable_auto"))
+                    module_exist and filament_detected and not disable_auto)
                 was_eligible = self._feeder_eligible.get(ch)
                 self._feeder_eligible[ch] = eligible
                 if was_eligible and not eligible:
+                    uid = self._channel_uids.get(ch, "")
+                    known = self._known_spools.get(ch)
+                    known_id = (
+                        known[1].get("id", 0)
+                        if known is not None else 0) or 0
+                    retain_known_spool = (
+                        self._can_retain_external_spool(ch))
                     logging.info(
-                        "[spoollink] ch%d: feeder no longer retains filament",
-                        ch)
-                    self._forget_known_spool(ch)
+                        "[spoollink] ch%d: feeder no longer retains filament: "
+                        "external_channel=%s module_exist=%s "
+                        "filament_detected=%s disable_auto=%s "
+                        "uid_present=%s uid_resolved=%s known_spool_id=%s "
+                        "retain_known_spool=%s",
+                        ch, ch in self._external_channels, module_exist,
+                        filament_detected, disable_auto, bool(uid),
+                        bool(uid and self._resolved_uids.get(ch) == uid),
+                        known_id, retain_known_spool)
+                    if not retain_known_spool:
+                        self._forget_known_spool(ch)
+
+    def _can_retain_external_spool(self, ch: int) -> bool:
+        if ch not in self._external_channels:
+            return False
+        uid = self._channel_uids.get(ch, "")
+        known = self._known_spools.get(ch)
+        return bool(
+            uid
+            and self._resolved_uids.get(ch) == uid
+            and known is not None
+            and known[0] == uid
+            and (known[1].get("id", 0) or 0) > 0)
 
     def _handle_toolhead_sensors(
             self, status: Dict[str, Any], eventtime: float) -> None:
@@ -435,6 +474,7 @@ class SpoolLink:
                     self._extruder_to_channel(self._toolhead_extruder) == ch,
                     retained_restore, load_clear_evidence)
             if (ch in self._known_spools
+                    and ch not in self._external_channels
                     and feeder_eligible
                     and (sensor_evidence
                          or retained_restore
@@ -462,6 +502,9 @@ class SpoolLink:
             self._metadata_clear_deadlines.pop(ch, None)
             if not same_known_uid:
                 self._release_recovery_hold(ch)
+            if ch in self._external_channels and eventtime > 0.:
+                self._mark_rfid_refresh(
+                    ch, eventtime, "external UID changed")
             logging.info("[spoollink] ch%d: card UID changed to %s, resolving",
                          ch, uid_hex)
             self._schedule_detected_resolution(ch, uid_hex)
@@ -513,7 +556,8 @@ class SpoolLink:
             self._schedule_detected_resolution(ch, uid)
             return
 
-        if (not uid and known is not None and known_id == old_spool_id
+        if (not uid and ch not in self._external_channels
+                and known is not None and known_id == old_spool_id
                 and (sensor_evidence or load_clear_evidence)):
             self._sensor_refresh_deadlines.pop(ch, None)
             self._metadata_clear_deadlines.pop(ch, None)
@@ -563,6 +607,7 @@ class SpoolLink:
             and known[0] == uid
             and (known[1].get("id", 0) or 0) == spool_id
             and not self._channel_uids.get(ch, "")
+            and ch not in self._external_channels
             and self._feeder_eligible.get(ch, False))
 
     async def _restore_known_spool(
@@ -679,6 +724,7 @@ class SpoolLink:
             known = self._known_spools.get(channel)
             retained_hold = bool(
                 hold_uid is None
+                and channel not in self._external_channels
                 and known is not None
                 and (known[1].get("id", 0) or 0) == hold_id
                 and self._feeder_eligible.get(channel, False))

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
@@ -68,6 +68,7 @@ class SpoolLink:
         self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
 
         self._channel_uids: Dict[int, str] = {}
+        self._channel_event_times: Dict[int, float] = {}
         self._channel_signatures: Dict[int, Tuple[Any, ...]] = {}
         self._resolved_uids: Dict[int, str] = {}
         self._fd_states: List[Any] = []
@@ -76,7 +77,9 @@ class SpoolLink:
         self._metadata_clear_deadlines: Dict[int, float] = {}
         self._resolution_tasks: Dict[int, "asyncio.Future"] = {}
         self._resolution_task_uids: Dict[int, str] = {}
-        self._queued_resolutions: Dict[int, str] = {}
+        self._resolution_task_event_times: Dict[int, Optional[float]] = {}
+        self._queued_resolutions: Dict[
+            int, Tuple[str, Optional[float]]] = {}
         self._recovery_holds: Dict[int, Tuple[Optional[str], int]] = {}
         self._known_spools: Dict[int, Tuple[str, dict]] = {}
         self._retention_tasks: Dict[int, "asyncio.Future"] = {}
@@ -135,6 +138,7 @@ class SpoolLink:
         for task in self._retention_tasks.values():
             task.cancel()
         self._channel_uids = {}
+        self._channel_event_times = {}
         self._channel_signatures = {}
         self._resolved_uids = {}
         self._fd_states = []
@@ -143,6 +147,7 @@ class SpoolLink:
         self._metadata_clear_deadlines = {}
         self._resolution_tasks = {}
         self._resolution_task_uids = {}
+        self._resolution_task_event_times = {}
         self._queued_resolutions = {}
         self._recovery_holds = {}
         self._known_spools = {}
@@ -266,6 +271,7 @@ class SpoolLink:
                         bool(uid and self._resolved_uids.get(ch) == uid),
                         known_id, retain_known_spool)
                     if not retain_known_spool:
+                        self._cancel_detected_resolution(ch)
                         self._forget_known_spool(ch)
 
     def _can_retain_external_spool(self, ch: int) -> bool:
@@ -416,6 +422,14 @@ class SpoolLink:
             info.get("VENDOR"), info.get("MAIN_TYPE"), info.get("SUB_TYPE"),
             info.get("OFFICIAL"), info.get("SKU"), info.get("SPOOL_ID"))
 
+    @staticmethod
+    def _card_event_time(info: Dict[str, Any]) -> Optional[float]:
+        value = info.get("CARD_EVENT_TIME")
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        event_time = float(value)
+        return event_time if event_time > 0. else None
+
     def _mark_rfid_refresh(
             self, ch: int, eventtime: float, reason: str) -> None:
         self._refresh_deadlines[ch] = eventtime + RFID_REFRESH_WINDOW
@@ -427,6 +441,13 @@ class SpoolLink:
             combined_clear_spool_id: int = 0) -> None:
         if not isinstance(info, dict):
             return
+        card_event_time = self._card_event_time(info)
+        previous_card_event_time = self._channel_event_times.get(ch)
+        if card_event_time is not None:
+            if (previous_card_event_time is not None
+                    and card_event_time <= previous_card_event_time):
+                return
+            self._channel_event_times[ch] = card_event_time
         uid_hex = self._uid_to_hex(info.get("CARD_UID"))
         prev = self._channel_uids.get(ch, "")
         signature = self._filament_signature(info)
@@ -435,11 +456,11 @@ class SpoolLink:
         self._channel_signatures[ch] = signature
 
         if not uid_hex:
+            self._cancel_detected_resolution(ch)
             self._resolved_uids.pop(ch, None)
             self._refreshing_channels.pop(ch, None)
             self._refresh_deadlines.pop(ch, None)
             self._metadata_clear_deadlines.pop(ch, None)
-            self._queued_resolutions.pop(ch, None)
             hold = self._recovery_holds.get(ch)
             retained_restore = bool(
                 ch in self._retention_tasks
@@ -505,9 +526,31 @@ class SpoolLink:
             if ch in self._external_channels and eventtime > 0.:
                 self._mark_rfid_refresh(
                     ch, eventtime, "external UID changed")
-            logging.info("[spoollink] ch%d: card UID changed to %s, resolving",
-                         ch, uid_hex)
-            self._schedule_detected_resolution(ch, uid_hex)
+            if card_event_time is not None:
+                logging.info(
+                    "[spoollink] ch%d: card event %.6f changed UID to %s, "
+                    "resolving", ch, card_event_time, uid_hex)
+            else:
+                logging.info(
+                    "[spoollink] ch%d: card UID changed to %s, resolving",
+                    ch, uid_hex)
+            self._schedule_detected_resolution(
+                ch, uid_hex, card_event_time)
+        elif card_event_time is not None:
+            known = self._known_spools.get(ch)
+            known_id = (
+                known[1].get("id", 0) if known is not None else 0) or 0
+            if (known is not None and known[0] == uid_hex
+                    and self._resolved_uids.get(ch) == uid_hex
+                    and known_id > 0):
+                self._recovery_holds[ch] = (uid_hex, known_id)
+            if eventtime > 0.:
+                self._mark_rfid_refresh(ch, eventtime, "card event")
+            logging.info(
+                "[spoollink] ch%d: card event %.6f for %s, resolving",
+                ch, card_event_time, uid_hex)
+            self._schedule_detected_resolution(
+                ch, uid_hex, card_event_time)
         elif (eventtime > 0. and prev_signature is not None
               and signature != prev_signature):
             self._mark_rfid_refresh(ch, eventtime, "card data updated")
@@ -553,7 +596,8 @@ class SpoolLink:
             logging.info(
                 "[spoollink] ch%d: same card %s cleared spool %s; re-resolving",
                 ch, uid, old_spool_id)
-            self._schedule_detected_resolution(ch, uid)
+            self._schedule_detected_resolution(
+                ch, uid, self._channel_event_times.get(ch))
             return
 
         if (not uid and ch not in self._external_channels
@@ -568,6 +612,8 @@ class SpoolLink:
             self._schedule_retained_restore(ch, known[0], known[1])
             return
 
+        if not uid or self._resolved_uids.get(ch) == uid:
+            self._cancel_detected_resolution(ch)
         if known_id == old_spool_id:
             self._forget_known_spool(ch)
 
@@ -581,6 +627,14 @@ class SpoolLink:
         self._resolved_uids.pop(ch, None)
         self._cancel_retention_task(ch)
         self._release_recovery_hold(ch)
+
+    def _cancel_detected_resolution(self, ch: int) -> None:
+        task = self._resolution_tasks.pop(ch, None)
+        self._resolution_task_uids.pop(ch, None)
+        self._resolution_task_event_times.pop(ch, None)
+        self._queued_resolutions.pop(ch, None)
+        if task is not None and not task.done():
+            task.cancel()
 
     def _cancel_retention_task(self, ch: int) -> None:
         task = self._retention_tasks.pop(ch, None)
@@ -647,26 +701,47 @@ class SpoolLink:
             self._recovery_holds.pop(ch, None)
         self._fire(self._sync_active_spool())
 
-    def _schedule_detected_resolution(self, ch: int, uid: str) -> None:
+    def _detected_resolution_is_current(
+            self, ch: int, uid: str,
+            card_event_time: Optional[float]) -> bool:
+        return bool(
+            self._channel_uids.get(ch) == uid
+            and (card_event_time is None
+                 or self._channel_event_times.get(ch) == card_event_time))
+
+    def _schedule_detected_resolution(
+            self, ch: int, uid: str,
+            card_event_time: Optional[float] = None) -> None:
         task = self._resolution_tasks.get(ch)
         if task is not None and not task.done():
-            if self._resolution_task_uids.get(ch) != uid:
-                self._queued_resolutions[ch] = uid
+            active = (
+                self._resolution_task_uids.get(ch),
+                self._resolution_task_event_times.get(ch))
+            queued = (uid, card_event_time)
+            if active != queued:
+                self._queued_resolutions[ch] = queued
             return
         task = asyncio.ensure_future(
-            self._resolve_spool(ch, card_uid=uid, expected_uid=uid))
+            self._resolve_spool(
+                ch, card_uid=uid, expected_uid=uid,
+                expected_card_event_time=card_event_time))
         self._resolution_tasks[ch] = task
         self._resolution_task_uids[ch] = uid
+        self._resolution_task_event_times[ch] = card_event_time
         task.add_done_callback(
-            lambda completed, channel=ch, card_uid=uid:
-                self._detected_resolution_done(channel, card_uid, completed))
+            lambda completed, channel=ch, card_uid=uid,
+            event_time=card_event_time:
+                self._detected_resolution_done(
+                    channel, card_uid, event_time, completed))
 
     def _detected_resolution_done(
-            self, ch: int, uid: str, task: "asyncio.Future") -> None:
+            self, ch: int, uid: str, card_event_time: Optional[float],
+            task: "asyncio.Future") -> None:
         if self._resolution_tasks.get(ch) is not task:
             return
         self._resolution_tasks.pop(ch, None)
         self._resolution_task_uids.pop(ch, None)
+        self._resolution_task_event_times.pop(ch, None)
 
         spool_id = None
         if not task.cancelled():
@@ -677,7 +752,9 @@ class SpoolLink:
                     "[spoollink] ch%d: card %s resolution failed: %s",
                     ch, uid, e, exc_info=e)
 
-        if spool_id and self._channel_uids.get(ch) == uid:
+        is_current = self._detected_resolution_is_current(
+            ch, uid, card_event_time)
+        if spool_id and is_current:
             self._resolved_uids[ch] = uid
             while len(self._ptc_spool_ids) <= ch:
                 self._ptc_spool_ids.append(0)
@@ -685,13 +762,17 @@ class SpoolLink:
                 self._ptc_spool_ids[ch] = spool_id
 
         hold = self._recovery_holds.get(ch)
-        if hold is not None and hold[0] == uid:
+        if hold is not None and hold[0] == uid and is_current:
             self._recovery_holds.pop(ch, None)
             self._fire(self._sync_active_spool())
 
-        queued_uid = self._queued_resolutions.pop(ch, None)
-        if queued_uid and self._channel_uids.get(ch) == queued_uid:
-            self._schedule_detected_resolution(ch, queued_uid)
+        queued = self._queued_resolutions.pop(ch, None)
+        if queued is not None:
+            queued_uid, queued_event_time = queued
+            if self._detected_resolution_is_current(
+                    ch, queued_uid, queued_event_time):
+                self._schedule_detected_resolution(
+                    ch, queued_uid, queued_event_time)
 
     # -- Active spool sync --------------------------------------------------
 
@@ -921,7 +1002,8 @@ class SpoolLink:
 
     async def _resolve_spool(
             self, channel: int, spool_id: Any = None, card_uid: Any = None,
-            expected_uid: Optional[str] = None) -> Optional[int]:
+            expected_uid: Optional[str] = None,
+            expected_card_event_time: Optional[float] = None) -> Optional[int]:
         spool_id = spool_id or None
         card_uid = card_uid or None
         if channel is None:
@@ -1008,10 +1090,12 @@ class SpoolLink:
             self._save_cache(card_uid, spool)
 
         if (expected_uid is not None
-                and self._channel_uids.get(channel) != expected_uid):
+                and not self._detected_resolution_is_current(
+                    channel, expected_uid, expected_card_event_time)):
             logging.info(
-                "[spoollink] ch%d: discarding stale resolution for card %s",
-                channel, expected_uid)
+                "[spoollink] ch%d: discarding stale resolution for card %s "
+                "event=%s", channel, expected_uid,
+                expected_card_event_time)
             return None
 
         return await self._apply_spool(

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 RESOLVE_METHOD = "spoollink_resolve_spool"
 SET_ENDPOINT = "spoollink/set"
 RFID_REFRESH_WINDOW = 5.0
+# Do not include terminal or unknown feeder states in empty-UID recovery.
+EMPTY_UID_RECOVERY_LOAD_STATES = {"load_heating"}
 
 
 def _unquote(value: str) -> str:
@@ -168,6 +170,11 @@ class SpoolLink:
         self._handle_feeder_status(status)
         self._handle_toolhead_sensors(status, eventtime)
 
+        # Capture same-update clear evidence before the empty-UID handler can
+        # discard the known spool. The spool-ID decision still runs afterward.
+        ptc = status.get("print_task_config")
+        combined_clear_spool_ids = self._combined_ptc_clear_spool_ids(ptc)
+
         # Process the RFID object before print_task_config. A single Klippy
         # status update may contain both a new card and a cleared spool ID;
         # using the current UID avoids resolving the card that was just removed.
@@ -179,9 +186,10 @@ class SpoolLink:
             info_list = fd.get("info")
             if info_list is not None:
                 for ch, info in enumerate(info_list):
-                    self._handle_filament_detect_channel(ch, info, eventtime)
+                    self._handle_filament_detect_channel(
+                        ch, info, eventtime,
+                        combined_clear_spool_ids.get(ch, 0))
 
-        ptc = status.get("print_task_config")
         if ptc is not None:
             self._handle_ptc_metadata(ptc, eventtime)
             spool_ids = ptc.get("filament_spool_id")
@@ -199,7 +207,9 @@ class SpoolLink:
                     new_id = (new_ids[ch] if ch < len(new_ids) else 0) or 0
                     if old_id > 0 and new_id == 0:
                         self._start_same_uid_recovery(
-                            ch, old_id, eventtime)
+                            ch, old_id, eventtime,
+                            combined_clear_spool_ids.get(ch) == old_id
+                            and self._has_automatic_load_evidence(ch))
                 self._ptc_spool_ids = new_ids
                 self._fire(self._sync_active_spool())
 
@@ -258,6 +268,18 @@ class SpoolLink:
             and eventtime <= self._sensor_refresh_deadlines.get(ch, 0.)
             and self._feeder_eligible.get(ch, False))
 
+    def _has_automatic_load_evidence(self, ch: int) -> bool:
+        feeder_state, feeder_action = self._feeder_load_states.get(
+            ch, (None, None))
+        sensor = self._toolhead_sensors.get(ch, {})
+        return bool(
+            self._feeder_eligible.get(ch, False)
+            and feeder_state == feeder_action
+            and feeder_state in EMPTY_UID_RECOVERY_LOAD_STATES
+            and sensor.get("filament_detected") is True
+            and sensor.get("enabled", True)
+            and self._extruder_to_channel(self._toolhead_extruder) == ch)
+
     @staticmethod
     def _deadline_remaining(deadline: float, eventtime: float) -> str:
         if deadline <= 0. or eventtime <= 0.:
@@ -267,6 +289,45 @@ class SpoolLink:
     @staticmethod
     def _field_is_clear(value: Any) -> bool:
         return value in (None, "", "NONE", "None")
+
+    def _combined_ptc_clear_spool_ids(
+            self, ptc: Any) -> Dict[int, int]:
+        if not isinstance(ptc, dict):
+            return {}
+        spool_ids = ptc.get("filament_spool_id")
+        if spool_ids is None:
+            return {}
+        new_ids = list(spool_ids or [])
+        vendors = ptc.get("filament_vendor")
+        types = ptc.get("filament_type")
+        new_vendors = (
+            list(vendors) if vendors is not None else self._ptc_vendors)
+        new_types = list(types) if types is not None else self._ptc_types
+        channels = max(
+            len(self._ptc_spool_ids), len(new_ids),
+            len(self._ptc_vendors), len(self._ptc_types),
+            len(new_vendors), len(new_types))
+        cleared: Dict[int, int] = {}
+        for ch in range(channels):
+            old_id = (self._ptc_spool_ids[ch]
+                      if ch < len(self._ptc_spool_ids) else 0) or 0
+            new_id = (new_ids[ch] if ch < len(new_ids) else 0) or 0
+            old_vendor = (self._ptc_vendors[ch]
+                          if ch < len(self._ptc_vendors) else None)
+            old_type = (self._ptc_types[ch]
+                        if ch < len(self._ptc_types) else None)
+            new_vendor = (
+                new_vendors[ch] if ch < len(new_vendors) else None)
+            new_type = new_types[ch] if ch < len(new_types) else None
+            was_populated = not (
+                self._field_is_clear(old_vendor)
+                and self._field_is_clear(old_type))
+            is_cleared = (
+                self._field_is_clear(new_vendor)
+                and self._field_is_clear(new_type))
+            if old_id > 0 and new_id == 0 and was_populated and is_cleared:
+                cleared[ch] = old_id
+        return cleared
 
     def _handle_ptc_metadata(
             self, ptc: Dict[str, Any], eventtime: float) -> None:
@@ -323,7 +384,8 @@ class SpoolLink:
             "[spoollink] ch%d: RFID refresh detected (%s)", ch, reason)
 
     def _handle_filament_detect_channel(
-            self, ch: int, info: Any, eventtime: float = 0.) -> None:
+            self, ch: int, info: Any, eventtime: float = 0.,
+            combined_clear_spool_id: int = 0) -> None:
         if not isinstance(info, dict):
             return
         uid_hex = self._uid_to_hex(info.get("CARD_UID"))
@@ -351,6 +413,10 @@ class SpoolLink:
                 ch, eventtime)
             feeder_state, feeder_action = self._feeder_load_states.get(
                 ch, (None, None))
+            load_clear_evidence = bool(
+                known_id > 0
+                and known_id == combined_clear_spool_id
+                and self._has_automatic_load_evidence(ch))
             if prev:
                 logging.info(
                     "[spoollink] ch%d: UID clear decision: "
@@ -358,7 +424,7 @@ class SpoolLink:
                     "feeder_state=%s feeder_action=%s "
                     "sensor_evidence=%s sensor_window=%s "
                     "toolhead_sensor=%s selected_toolhead=%s "
-                    "retained_restore=%s",
+                    "retained_restore=%s load_clear_evidence=%s",
                     ch, known_id, feeder_eligible, feeder_state,
                     feeder_action, sensor_evidence,
                     self._deadline_remaining(
@@ -367,13 +433,14 @@ class SpoolLink:
                     self._toolhead_sensors.get(ch, {}).get(
                         "filament_detected"),
                     self._extruder_to_channel(self._toolhead_extruder) == ch,
-                    retained_restore)
+                    retained_restore, load_clear_evidence)
             if (ch in self._known_spools
                     and feeder_eligible
                     and (sensor_evidence
-                         or retained_restore)):
+                         or retained_restore
+                         or load_clear_evidence)):
                 logging.info(
-                    "[spoollink] ch%d: UID cleared during toolhead transition; "
+                    "[spoollink] ch%d: UID cleared during qualified load; "
                     "retaining spool", ch)
             else:
                 self._forget_known_spool(ch)
@@ -403,7 +470,8 @@ class SpoolLink:
             self._mark_rfid_refresh(ch, eventtime, "card data updated")
 
     def _start_same_uid_recovery(
-            self, ch: int, old_spool_id: int, eventtime: float) -> None:
+            self, ch: int, old_spool_id: int, eventtime: float,
+            load_clear_evidence: bool = False) -> None:
         uid = self._channel_uids.get(ch, "")
         refresh_deadline = self._refresh_deadlines.get(ch, 0.)
         metadata_deadline = self._metadata_clear_deadlines.get(ch, 0.)
@@ -422,7 +490,8 @@ class SpoolLink:
             "uid_present=%s uid_resolved=%s known_spool_id=%s "
             "feeder_eligible=%s feeder_state=%s feeder_action=%s "
             "sensor_evidence=%s sensor_window=%s reader_window=%s "
-            "metadata_window=%s toolhead_sensor=%s selected_toolhead=%s",
+            "metadata_window=%s toolhead_sensor=%s selected_toolhead=%s "
+            "load_clear_evidence=%s",
             ch, old_spool_id, bool(uid),
             bool(uid and self._resolved_uids.get(ch) == uid), known_id,
             feeder_eligible, feeder_state, feeder_action, sensor_evidence,
@@ -431,7 +500,8 @@ class SpoolLink:
             self._deadline_remaining(refresh_deadline, eventtime),
             self._deadline_remaining(metadata_deadline, eventtime),
             self._toolhead_sensors.get(ch, {}).get("filament_detected"),
-            self._extruder_to_channel(self._toolhead_extruder) == ch)
+            self._extruder_to_channel(self._toolhead_extruder) == ch,
+            load_clear_evidence)
         if (uid and self._resolved_uids.get(ch) == uid
                 and has_refresh_evidence):
             self._refresh_deadlines.pop(ch, None)
@@ -444,8 +514,9 @@ class SpoolLink:
             return
 
         if (not uid and known is not None and known_id == old_spool_id
-                and sensor_evidence):
+                and (sensor_evidence or load_clear_evidence)):
             self._sensor_refresh_deadlines.pop(ch, None)
+            self._metadata_clear_deadlines.pop(ch, None)
             self._recovery_holds[ch] = (None, old_spool_id)
             logging.info(
                 "[spoollink] ch%d: automatic read lost UID; restoring spool %s",

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
@@ -66,7 +66,12 @@ class SpoolLink:
         self._resolution_tasks: Dict[int, "asyncio.Future"] = {}
         self._resolution_task_uids: Dict[int, str] = {}
         self._queued_resolutions: Dict[int, str] = {}
-        self._recovery_holds: Dict[int, Tuple[str, int]] = {}
+        self._recovery_holds: Dict[int, Tuple[Optional[str], int]] = {}
+        self._known_spools: Dict[int, Tuple[str, dict]] = {}
+        self._retention_tasks: Dict[int, "asyncio.Future"] = {}
+        self._feeder_eligible: Dict[int, bool] = {}
+        self._toolhead_sensors: Dict[int, Dict[str, Any]] = {}
+        self._sensor_refresh_deadlines: Dict[int, float] = {}
         self._toolhead_extruder: str = "extruder"
         self._ptc_vendors: List[str] = []
         self._ptc_types: List[str] = []
@@ -96,12 +101,24 @@ class SpoolLink:
             "print_task_config": [
                 "filament_spool_id", "filament_vendor", "filament_type"],
             "toolhead": ["extruder"],
+            "filament_feed left": None,
+            "filament_feed right": None,
+            "filament_motion_sensor e0_filament": [
+                "filament_detected", "enabled"],
+            "filament_motion_sensor e1_filament": [
+                "filament_detected", "enabled"],
+            "filament_motion_sensor e2_filament": [
+                "filament_detected", "enabled"],
+            "filament_motion_sensor e3_filament": [
+                "filament_detected", "enabled"],
         }, self._handle_status_update, {})
         self._handle_status_update(status, 0.)
 
     def _handle_klippy_disconnect(self) -> None:
         logging.info("[spoollink] Klippy disconnected")
         for task in self._resolution_tasks.values():
+            task.cancel()
+        for task in self._retention_tasks.values():
             task.cancel()
         self._channel_uids = {}
         self._channel_signatures = {}
@@ -114,6 +131,11 @@ class SpoolLink:
         self._resolution_task_uids = {}
         self._queued_resolutions = {}
         self._recovery_holds = {}
+        self._known_spools = {}
+        self._retention_tasks = {}
+        self._feeder_eligible = {}
+        self._toolhead_sensors = {}
+        self._sensor_refresh_deadlines = {}
         self._ptc_vendors = []
         self._ptc_types = []
         self._ptc_spool_ids = []
@@ -137,6 +159,12 @@ class SpoolLink:
                              self._toolhead_extruder, extruder)
                 self._toolhead_extruder = extruder
                 self._fire(self._sync_active_spool())
+
+        # Feeder presence and toolhead-sensor transitions distinguish an
+        # automatic RFID refresh from a manual clear. Process them first so a
+        # combined update can qualify the RFID and spool-ID changes below.
+        self._handle_feeder_status(status)
+        self._handle_toolhead_sensors(status, eventtime)
 
         # Process the RFID object before print_task_config. A single Klippy
         # status update may contain both a new card and a cleared spool ID;
@@ -172,6 +200,58 @@ class SpoolLink:
                             ch, old_id, eventtime)
                 self._ptc_spool_ids = new_ids
                 self._fire(self._sync_active_spool())
+
+    def _handle_feeder_status(self, status: Dict[str, Any]) -> None:
+        modules = {
+            "filament_feed left": {"extruder0": 0, "extruder1": 1},
+            "filament_feed right": {"extruder2": 2, "extruder3": 3},
+        }
+        for object_name, channels in modules.items():
+            feed = status.get(object_name)
+            if not isinstance(feed, dict):
+                continue
+            for extruder, ch in channels.items():
+                state = feed.get(extruder)
+                if not isinstance(state, dict):
+                    continue
+                eligible = bool(
+                    state.get("module_exist")
+                    and state.get("filament_detected")
+                    and not state.get("disable_auto"))
+                was_eligible = self._feeder_eligible.get(ch)
+                self._feeder_eligible[ch] = eligible
+                if was_eligible and not eligible:
+                    logging.info(
+                        "[spoollink] ch%d: feeder no longer retains filament",
+                        ch)
+                    self._forget_known_spool(ch)
+
+    def _handle_toolhead_sensors(
+            self, status: Dict[str, Any], eventtime: float) -> None:
+        for ch in range(4):
+            key = f"filament_motion_sensor e{ch}_filament"
+            update = status.get(key)
+            if not isinstance(update, dict):
+                continue
+            state = self._toolhead_sensors.setdefault(ch, {})
+            previous = state.get("filament_detected")
+            state.update(update)
+            present = state.get("filament_detected")
+            if (eventtime > 0. and previous is not None
+                    and present is not None and present != previous
+                    and state.get("enabled", True)
+                    and self._feeder_eligible.get(ch, False)):
+                self._sensor_refresh_deadlines[ch] = (
+                    eventtime + RFID_REFRESH_WINDOW)
+                logging.debug(
+                    "[spoollink] ch%d: toolhead filament transition", ch)
+
+    def _has_sensor_refresh_evidence(
+            self, ch: int, eventtime: float) -> bool:
+        return (
+            eventtime > 0.
+            and eventtime <= self._sensor_refresh_deadlines.get(ch, 0.)
+            and self._feeder_eligible.get(ch, False))
 
     @staticmethod
     def _field_is_clear(value: Any) -> bool:
@@ -248,15 +328,37 @@ class SpoolLink:
             self._refresh_deadlines.pop(ch, None)
             self._metadata_clear_deadlines.pop(ch, None)
             self._queued_resolutions.pop(ch, None)
-            self._release_recovery_hold(ch)
+            hold = self._recovery_holds.get(ch)
+            retained_restore = bool(
+                ch in self._retention_tasks
+                or (hold is not None and hold[0] is None))
+            if (ch in self._known_spools
+                    and self._feeder_eligible.get(ch, False)
+                    and (self._has_sensor_refresh_evidence(ch, eventtime)
+                         or retained_restore)):
+                logging.info(
+                    "[spoollink] ch%d: UID cleared during toolhead transition; "
+                    "retaining spool", ch)
+            else:
+                self._forget_known_spool(ch)
             return
 
         if uid_hex and uid_hex != prev:
+            known = self._known_spools.get(ch)
+            same_known_uid = known is not None and known[0] == uid_hex
+            if same_known_uid:
+                self._cancel_retention_task(ch)
+                known_id = (known[1].get("id", 0) or 0)
+                if known_id:
+                    self._recovery_holds[ch] = (uid_hex, known_id)
+            else:
+                self._forget_known_spool(ch)
             self._resolved_uids.pop(ch, None)
             self._refreshing_channels.pop(ch, None)
             self._refresh_deadlines.pop(ch, None)
             self._metadata_clear_deadlines.pop(ch, None)
-            self._release_recovery_hold(ch)
+            if not same_known_uid:
+                self._release_recovery_hold(ch)
             logging.info("[spoollink] ch%d: card UID changed to %s, resolving",
                          ch, uid_hex)
             self._schedule_detected_resolution(ch, uid_hex)
@@ -272,20 +374,106 @@ class SpoolLink:
         has_refresh_evidence = (
             eventtime > 0.
             and eventtime <= max(refresh_deadline, metadata_deadline))
-        if (not uid or self._resolved_uids.get(ch) != uid
-                or not has_refresh_evidence):
+        if (uid and self._resolved_uids.get(ch) == uid
+                and has_refresh_evidence):
+            self._refresh_deadlines.pop(ch, None)
+            self._metadata_clear_deadlines.pop(ch, None)
+            self._recovery_holds[ch] = (uid, old_spool_id)
+            logging.info(
+                "[spoollink] ch%d: same card %s cleared spool %s; re-resolving",
+                ch, uid, old_spool_id)
+            self._schedule_detected_resolution(ch, uid)
             return
-        self._refresh_deadlines.pop(ch, None)
-        self._metadata_clear_deadlines.pop(ch, None)
-        self._recovery_holds[ch] = (uid, old_spool_id)
-        logging.info(
-            "[spoollink] ch%d: same card %s cleared spool %s; re-resolving",
-            ch, uid, old_spool_id)
-        self._schedule_detected_resolution(ch, uid)
+
+        known = self._known_spools.get(ch)
+        known_id = (known[1].get("id", 0) if known is not None else 0) or 0
+        if (not uid and known is not None and known_id == old_spool_id
+                and self._has_sensor_refresh_evidence(ch, eventtime)):
+            self._sensor_refresh_deadlines.pop(ch, None)
+            self._recovery_holds[ch] = (None, old_spool_id)
+            logging.info(
+                "[spoollink] ch%d: automatic read lost UID; restoring spool %s",
+                ch, old_spool_id)
+            self._schedule_retained_restore(ch, known[0], known[1])
+            return
+
+        if known_id == old_spool_id:
+            self._forget_known_spool(ch)
 
     def _release_recovery_hold(self, ch: int) -> None:
         if self._recovery_holds.pop(ch, None) is not None:
             self._fire(self._sync_active_spool())
+
+    def _forget_known_spool(self, ch: int) -> None:
+        self._known_spools.pop(ch, None)
+        self._sensor_refresh_deadlines.pop(ch, None)
+        self._resolved_uids.pop(ch, None)
+        self._cancel_retention_task(ch)
+        self._release_recovery_hold(ch)
+
+    def _cancel_retention_task(self, ch: int) -> None:
+        task = self._retention_tasks.pop(ch, None)
+        if task is not None and not task.done():
+            task.cancel()
+
+    def _schedule_retained_restore(
+            self, ch: int, uid: str, spool: dict) -> None:
+        task = self._retention_tasks.get(ch)
+        if task is not None and not task.done():
+            return
+        task = asyncio.ensure_future(
+            self._restore_known_spool(ch, uid, spool))
+        self._retention_tasks[ch] = task
+        task.add_done_callback(
+            lambda completed, channel=ch, card_uid=uid:
+                self._retained_restore_done(channel, card_uid, completed))
+
+    def _can_restore_known_spool(
+            self, ch: int, uid: str, spool_id: int) -> bool:
+        known = self._known_spools.get(ch)
+        return bool(
+            known is not None
+            and known[0] == uid
+            and (known[1].get("id", 0) or 0) == spool_id
+            and not self._channel_uids.get(ch, "")
+            and self._feeder_eligible.get(ch, False))
+
+    async def _restore_known_spool(
+            self, ch: int, uid: str, spool: dict) -> Optional[int]:
+        await asyncio.sleep(0)
+        spool_id = (spool.get("id", 0) or 0)
+        if not self._can_restore_known_spool(ch, uid, spool_id):
+            return None
+        # The reader reported no UID. Restore the spool metadata without
+        # claiming that a card is currently readable.
+        return await self._apply_spool(ch, spool, "")
+
+    def _retained_restore_done(
+            self, ch: int, uid: str, task: "asyncio.Future") -> None:
+        if self._retention_tasks.get(ch) is not task:
+            return
+        self._retention_tasks.pop(ch, None)
+        if task.cancelled():
+            return
+        try:
+            spool_id = task.result()
+        except Exception as e:
+            logging.error(
+                "[spoollink] ch%d: retained spool restore failed: %s",
+                ch, e, exc_info=e)
+            self._forget_known_spool(ch)
+            return
+        if not spool_id or not self._can_restore_known_spool(ch, uid, spool_id):
+            self._forget_known_spool(ch)
+            return
+        while len(self._ptc_spool_ids) <= ch:
+            self._ptc_spool_ids.append(0)
+        if not self._ptc_spool_ids[ch]:
+            self._ptc_spool_ids[ch] = spool_id
+        hold = self._recovery_holds.get(ch)
+        if hold == (None, spool_id):
+            self._recovery_holds.pop(ch, None)
+        self._fire(self._sync_active_spool())
 
     def _schedule_detected_resolution(self, ch: int, uid: str) -> None:
         task = self._resolution_tasks.get(ch)
@@ -359,9 +547,18 @@ class SpoolLink:
         spool_id = (self._ptc_spool_ids[channel]
                     if channel < len(self._ptc_spool_ids) else 0) or 0
         hold = self._recovery_holds.get(channel)
-        if (spool_id == 0 and hold is not None
-                and self._channel_uids.get(channel) == hold[0]):
-            spool_id = hold[1]
+        if spool_id == 0 and hold is not None:
+            hold_uid, hold_id = hold
+            known = self._known_spools.get(channel)
+            retained_hold = bool(
+                hold_uid is None
+                and known is not None
+                and (known[1].get("id", 0) or 0) == hold_id
+                and self._feeder_eligible.get(channel, False))
+            if ((hold_uid is not None
+                 and self._channel_uids.get(channel) == hold_uid)
+                    or retained_hold):
+                spool_id = hold_id
         if spool_id == self._active_spool_id:
             return
         logging.info("[spoollink] set active spool: channel=%d spool_id=%s → %s",
@@ -705,6 +902,7 @@ class SpoolLink:
             logging.info("[spoollink] ch%d: spool %s applied", channel, spool_id)
             if uid_hex:
                 self._resolved_uids[channel] = uid_hex
+                self._known_spools[channel] = (uid_hex, spool)
             return spool_id
         return None
 

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
@@ -14,7 +14,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from ..confighelper import ConfigHelper
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 RESOLVE_METHOD = "spoollink_resolve_spool"
 SET_ENDPOINT = "spoollink/set"
+RFID_REFRESH_WINDOW = 5.0
 
 
 def _unquote(value: str) -> str:
@@ -56,7 +57,19 @@ class SpoolLink:
         self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
 
         self._channel_uids: Dict[int, str] = {}
+        self._channel_signatures: Dict[int, Tuple[Any, ...]] = {}
+        self._resolved_uids: Dict[int, str] = {}
+        self._fd_states: List[Any] = []
+        self._refreshing_channels: Dict[int, bool] = {}
+        self._refresh_deadlines: Dict[int, float] = {}
+        self._metadata_clear_deadlines: Dict[int, float] = {}
+        self._resolution_tasks: Dict[int, "asyncio.Future"] = {}
+        self._resolution_task_uids: Dict[int, str] = {}
+        self._queued_resolutions: Dict[int, str] = {}
+        self._recovery_holds: Dict[int, Tuple[str, int]] = {}
         self._toolhead_extruder: str = "extruder"
+        self._ptc_vendors: List[str] = []
+        self._ptc_types: List[str] = []
         self._ptc_spool_ids: List[int] = []
         self._active_spool_id: Optional[int] = None
 
@@ -80,14 +93,29 @@ class SpoolLink:
         logging.info("[spoollink] Klippy ready, subscribing to objects")
         status = await self.klippy_apis.subscribe_objects({
             "filament_detect": None,
-            "print_task_config": ["filament_spool_id"],
+            "print_task_config": [
+                "filament_spool_id", "filament_vendor", "filament_type"],
             "toolhead": ["extruder"],
         }, self._handle_status_update, {})
         self._handle_status_update(status, 0.)
 
     def _handle_klippy_disconnect(self) -> None:
         logging.info("[spoollink] Klippy disconnected")
+        for task in self._resolution_tasks.values():
+            task.cancel()
         self._channel_uids = {}
+        self._channel_signatures = {}
+        self._resolved_uids = {}
+        self._fd_states = []
+        self._refreshing_channels = {}
+        self._refresh_deadlines = {}
+        self._metadata_clear_deadlines = {}
+        self._resolution_tasks = {}
+        self._resolution_task_uids = {}
+        self._queued_resolutions = {}
+        self._recovery_holds = {}
+        self._ptc_vendors = []
+        self._ptc_types = []
         self._ptc_spool_ids = []
         self._active_spool_id = None
 
@@ -110,33 +138,200 @@ class SpoolLink:
                 self._toolhead_extruder = extruder
                 self._fire(self._sync_active_spool())
 
+        # Process the RFID object before print_task_config. A single Klippy
+        # status update may contain both a new card and a cleared spool ID;
+        # using the current UID avoids resolving the card that was just removed.
+        fd = status.get("filament_detect")
+        if fd is not None:
+            states = fd.get("state")
+            if states is not None:
+                self._handle_filament_detect_states(states, eventtime)
+            info_list = fd.get("info")
+            if info_list is not None:
+                for ch, info in enumerate(info_list):
+                    self._handle_filament_detect_channel(ch, info, eventtime)
+
         ptc = status.get("print_task_config")
         if ptc is not None:
+            self._handle_ptc_metadata(ptc, eventtime)
             spool_ids = ptc.get("filament_spool_id")
-            new_ids = list(spool_ids or [])
+            if spool_ids is not None:
+                new_ids = list(spool_ids or [])
+            else:
+                new_ids = self._ptc_spool_ids
             if new_ids != self._ptc_spool_ids:
                 logging.info("[spoollink] spool_ids changed: %s → %s",
                              self._ptc_spool_ids, new_ids)
+                channels = max(len(self._ptc_spool_ids), len(new_ids))
+                for ch in range(channels):
+                    old_id = (self._ptc_spool_ids[ch]
+                              if ch < len(self._ptc_spool_ids) else 0) or 0
+                    new_id = (new_ids[ch] if ch < len(new_ids) else 0) or 0
+                    if old_id > 0 and new_id == 0:
+                        self._start_same_uid_recovery(
+                            ch, old_id, eventtime)
                 self._ptc_spool_ids = new_ids
                 self._fire(self._sync_active_spool())
 
-        fd = status.get("filament_detect")
-        if fd is None:
-            return
-        info_list = fd.get("info", [])
-        for ch, info in enumerate(info_list):
-            self._handle_filament_detect_channel(ch, info)
+    @staticmethod
+    def _field_is_clear(value: Any) -> bool:
+        return value in (None, "", "NONE", "None")
 
-    def _handle_filament_detect_channel(self, ch: int, info: Any) -> None:
+    def _handle_ptc_metadata(
+            self, ptc: Dict[str, Any], eventtime: float) -> None:
+        vendors = ptc.get("filament_vendor")
+        types = ptc.get("filament_type")
+        new_vendors = list(vendors) if vendors is not None else self._ptc_vendors
+        new_types = list(types) if types is not None else self._ptc_types
+        channels = max(
+            len(self._ptc_vendors), len(self._ptc_types),
+            len(new_vendors), len(new_types))
+        for ch in range(channels):
+            old_vendor = (self._ptc_vendors[ch]
+                          if ch < len(self._ptc_vendors) else None)
+            old_type = (self._ptc_types[ch]
+                        if ch < len(self._ptc_types) else None)
+            new_vendor = new_vendors[ch] if ch < len(new_vendors) else None
+            new_type = new_types[ch] if ch < len(new_types) else None
+            was_populated = not (self._field_is_clear(old_vendor)
+                                 and self._field_is_clear(old_type))
+            is_cleared = (self._field_is_clear(new_vendor)
+                          and self._field_is_clear(new_type))
+            if eventtime > 0. and was_populated and is_cleared:
+                self._metadata_clear_deadlines[ch] = (
+                    eventtime + RFID_REFRESH_WINDOW)
+        self._ptc_vendors = new_vendors
+        self._ptc_types = new_types
+
+    def _handle_filament_detect_states(
+            self, states: Any, eventtime: float) -> None:
+        if not isinstance(states, (list, tuple)):
+            return
+        new_states = list(states)
+        for ch, state in enumerate(new_states):
+            prev = self._fd_states[ch] if ch < len(self._fd_states) else None
+            if state not in (None, 0) and prev in (None, 0):
+                self._refreshing_channels[ch] = True
+                logging.debug(
+                    "[spoollink] ch%d: RFID reader active", ch)
+            elif (state in (None, 0) and prev not in (None, 0)
+                  and self._refreshing_channels.pop(ch, None)):
+                self._mark_rfid_refresh(ch, eventtime, "reader completed")
+        self._fd_states = new_states
+
+    @staticmethod
+    def _filament_signature(info: Dict[str, Any]) -> Tuple[Any, ...]:
+        return (
+            info.get("VENDOR"), info.get("MAIN_TYPE"), info.get("SUB_TYPE"),
+            info.get("OFFICIAL"), info.get("SKU"), info.get("SPOOL_ID"))
+
+    def _mark_rfid_refresh(
+            self, ch: int, eventtime: float, reason: str) -> None:
+        self._refresh_deadlines[ch] = eventtime + RFID_REFRESH_WINDOW
+        logging.debug(
+            "[spoollink] ch%d: RFID refresh detected (%s)", ch, reason)
+
+    def _handle_filament_detect_channel(
+            self, ch: int, info: Any, eventtime: float = 0.) -> None:
         if not isinstance(info, dict):
             return
         uid_hex = self._uid_to_hex(info.get("CARD_UID"))
         prev = self._channel_uids.get(ch, "")
+        signature = self._filament_signature(info)
+        prev_signature = self._channel_signatures.get(ch)
         self._channel_uids[ch] = uid_hex
+        self._channel_signatures[ch] = signature
+
+        if not uid_hex:
+            self._resolved_uids.pop(ch, None)
+            self._refreshing_channels.pop(ch, None)
+            self._refresh_deadlines.pop(ch, None)
+            self._metadata_clear_deadlines.pop(ch, None)
+            self._queued_resolutions.pop(ch, None)
+            self._release_recovery_hold(ch)
+            return
+
         if uid_hex and uid_hex != prev:
+            self._resolved_uids.pop(ch, None)
+            self._refreshing_channels.pop(ch, None)
+            self._refresh_deadlines.pop(ch, None)
+            self._metadata_clear_deadlines.pop(ch, None)
+            self._release_recovery_hold(ch)
             logging.info("[spoollink] ch%d: card UID changed to %s, resolving",
                          ch, uid_hex)
-            self._fire(self._resolve_spool(ch, card_uid=uid_hex))
+            self._schedule_detected_resolution(ch, uid_hex)
+        elif (eventtime > 0. and prev_signature is not None
+              and signature != prev_signature):
+            self._mark_rfid_refresh(ch, eventtime, "card data updated")
+
+    def _start_same_uid_recovery(
+            self, ch: int, old_spool_id: int, eventtime: float) -> None:
+        uid = self._channel_uids.get(ch, "")
+        refresh_deadline = self._refresh_deadlines.get(ch, 0.)
+        metadata_deadline = self._metadata_clear_deadlines.get(ch, 0.)
+        has_refresh_evidence = (
+            eventtime > 0.
+            and eventtime <= max(refresh_deadline, metadata_deadline))
+        if (not uid or self._resolved_uids.get(ch) != uid
+                or not has_refresh_evidence):
+            return
+        self._refresh_deadlines.pop(ch, None)
+        self._metadata_clear_deadlines.pop(ch, None)
+        self._recovery_holds[ch] = (uid, old_spool_id)
+        logging.info(
+            "[spoollink] ch%d: same card %s cleared spool %s; re-resolving",
+            ch, uid, old_spool_id)
+        self._schedule_detected_resolution(ch, uid)
+
+    def _release_recovery_hold(self, ch: int) -> None:
+        if self._recovery_holds.pop(ch, None) is not None:
+            self._fire(self._sync_active_spool())
+
+    def _schedule_detected_resolution(self, ch: int, uid: str) -> None:
+        task = self._resolution_tasks.get(ch)
+        if task is not None and not task.done():
+            if self._resolution_task_uids.get(ch) != uid:
+                self._queued_resolutions[ch] = uid
+            return
+        task = asyncio.ensure_future(
+            self._resolve_spool(ch, card_uid=uid, expected_uid=uid))
+        self._resolution_tasks[ch] = task
+        self._resolution_task_uids[ch] = uid
+        task.add_done_callback(
+            lambda completed, channel=ch, card_uid=uid:
+                self._detected_resolution_done(channel, card_uid, completed))
+
+    def _detected_resolution_done(
+            self, ch: int, uid: str, task: "asyncio.Future") -> None:
+        if self._resolution_tasks.get(ch) is not task:
+            return
+        self._resolution_tasks.pop(ch, None)
+        self._resolution_task_uids.pop(ch, None)
+
+        spool_id = None
+        if not task.cancelled():
+            try:
+                spool_id = task.result()
+            except Exception as e:
+                logging.error(
+                    "[spoollink] ch%d: card %s resolution failed: %s",
+                    ch, uid, e, exc_info=e)
+
+        if spool_id and self._channel_uids.get(ch) == uid:
+            self._resolved_uids[ch] = uid
+            while len(self._ptc_spool_ids) <= ch:
+                self._ptc_spool_ids.append(0)
+            if not self._ptc_spool_ids[ch]:
+                self._ptc_spool_ids[ch] = spool_id
+
+        hold = self._recovery_holds.get(ch)
+        if hold is not None and hold[0] == uid:
+            self._recovery_holds.pop(ch, None)
+            self._fire(self._sync_active_spool())
+
+        queued_uid = self._queued_resolutions.pop(ch, None)
+        if queued_uid and self._channel_uids.get(ch) == queued_uid:
+            self._schedule_detected_resolution(ch, queued_uid)
 
     # -- Active spool sync --------------------------------------------------
 
@@ -163,6 +358,10 @@ class SpoolLink:
         channel = self._extruder_to_channel(self._toolhead_extruder)
         spool_id = (self._ptc_spool_ids[channel]
                     if channel < len(self._ptc_spool_ids) else 0) or 0
+        hold = self._recovery_holds.get(channel)
+        if (spool_id == 0 and hold is not None
+                and self._channel_uids.get(channel) == hold[0]):
+            spool_id = hold[1]
         if spool_id == self._active_spool_id:
             return
         logging.info("[spoollink] set active spool: channel=%d spool_id=%s → %s",
@@ -350,13 +549,14 @@ class SpoolLink:
 
     # -- Resolution ---------------------------------------------------------
 
-    async def _resolve_spool(self, channel: int, spool_id: Any = None,
-                             card_uid: Any = None) -> None:
+    async def _resolve_spool(
+            self, channel: int, spool_id: Any = None, card_uid: Any = None,
+            expected_uid: Optional[str] = None) -> Optional[int]:
         spool_id = spool_id or None
         card_uid = card_uid or None
         if channel is None:
             logging.error("[spoollink] resolve_spool: missing channel")
-            return
+            return None
         logging.debug("[spoollink] ch%d: resolve spool_id=%s card_uid=%s",
                       channel, spool_id, card_uid)
         spool_by_id = None
@@ -389,7 +589,7 @@ class SpoolLink:
                 f"SpoolLink: E{channel + 1} card {card_uid} "
                 f"assigned to multiple spools: {ids}",
                 status="error")
-            return
+            return None
         spool_by_card = spools_by_card[0] if spools_by_card else None
         spool = spool_by_id or spool_by_card
         cached = False
@@ -408,7 +608,7 @@ class SpoolLink:
                         channel,
                         f"SpoolLink: E{channel + 1} no spool found for card {card_uid}",
                         status="error")
-                return
+                return None
 
         if card_uid is not None and spool_by_id is not None:
             if card_uid.upper() not in _parse_card_uids(spool_by_id):
@@ -437,10 +637,18 @@ class SpoolLink:
         if card_uid is not None and spoolman_ok:
             self._save_cache(card_uid, spool)
 
-        await self._apply_spool(channel, spool, card_uid or "", cached=cached)
+        if (expected_uid is not None
+                and self._channel_uids.get(channel) != expected_uid):
+            logging.info(
+                "[spoollink] ch%d: discarding stale resolution for card %s",
+                channel, expected_uid)
+            return None
+
+        return await self._apply_spool(
+            channel, spool, card_uid or "", cached=cached)
 
     async def _apply_spool(self, channel: int, spool: dict, uid_hex: str,
-                           cached: bool = False) -> None:
+                           cached: bool = False) -> Optional[int]:
         spool_id = spool.get("id", 0)
         filament = spool.get("filament", {})
         material = filament.get("material", "PLA")
@@ -495,6 +703,10 @@ class SpoolLink:
         reply = await self._spoollink_set(channel, message, info=info)
         if reply is not None:
             logging.info("[spoollink] ch%d: spool %s applied", channel, spool_id)
+            if uid_hex:
+                self._resolved_uids[channel] = uid_hex
+            return spool_id
+        return None
 
 
 def load_component(config: ConfigHelper) -> SpoolLink:

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
@@ -70,6 +70,7 @@ class SpoolLink:
         self._known_spools: Dict[int, Tuple[str, dict]] = {}
         self._retention_tasks: Dict[int, "asyncio.Future"] = {}
         self._feeder_eligible: Dict[int, bool] = {}
+        self._feeder_load_states: Dict[int, Tuple[Any, Any]] = {}
         self._toolhead_sensors: Dict[int, Dict[str, Any]] = {}
         self._sensor_refresh_deadlines: Dict[int, float] = {}
         self._toolhead_extruder: str = "extruder"
@@ -134,6 +135,7 @@ class SpoolLink:
         self._known_spools = {}
         self._retention_tasks = {}
         self._feeder_eligible = {}
+        self._feeder_load_states = {}
         self._toolhead_sensors = {}
         self._sensor_refresh_deadlines = {}
         self._ptc_vendors = []
@@ -214,6 +216,9 @@ class SpoolLink:
                 state = feed.get(extruder)
                 if not isinstance(state, dict):
                     continue
+                self._feeder_load_states[ch] = (
+                    state.get("channel_state"),
+                    state.get("channel_action_state"))
                 eligible = bool(
                     state.get("module_exist")
                     and state.get("filament_detected")
@@ -252,6 +257,12 @@ class SpoolLink:
             eventtime > 0.
             and eventtime <= self._sensor_refresh_deadlines.get(ch, 0.)
             and self._feeder_eligible.get(ch, False))
+
+    @staticmethod
+    def _deadline_remaining(deadline: float, eventtime: float) -> str:
+        if deadline <= 0. or eventtime <= 0.:
+            return "none"
+        return f"{deadline - eventtime:+.3f}s"
 
     @staticmethod
     def _field_is_clear(value: Any) -> bool:
@@ -332,9 +343,34 @@ class SpoolLink:
             retained_restore = bool(
                 ch in self._retention_tasks
                 or (hold is not None and hold[0] is None))
+            known = self._known_spools.get(ch)
+            known_id = (
+                known[1].get("id", 0) if known is not None else 0) or 0
+            feeder_eligible = self._feeder_eligible.get(ch, False)
+            sensor_evidence = self._has_sensor_refresh_evidence(
+                ch, eventtime)
+            feeder_state, feeder_action = self._feeder_load_states.get(
+                ch, (None, None))
+            if prev:
+                logging.info(
+                    "[spoollink] ch%d: UID clear decision: "
+                    "known_spool_id=%s feeder_eligible=%s "
+                    "feeder_state=%s feeder_action=%s "
+                    "sensor_evidence=%s sensor_window=%s "
+                    "toolhead_sensor=%s selected_toolhead=%s "
+                    "retained_restore=%s",
+                    ch, known_id, feeder_eligible, feeder_state,
+                    feeder_action, sensor_evidence,
+                    self._deadline_remaining(
+                        self._sensor_refresh_deadlines.get(ch, 0.),
+                        eventtime),
+                    self._toolhead_sensors.get(ch, {}).get(
+                        "filament_detected"),
+                    self._extruder_to_channel(self._toolhead_extruder) == ch,
+                    retained_restore)
             if (ch in self._known_spools
-                    and self._feeder_eligible.get(ch, False)
-                    and (self._has_sensor_refresh_evidence(ch, eventtime)
+                    and feeder_eligible
+                    and (sensor_evidence
                          or retained_restore)):
                 logging.info(
                     "[spoollink] ch%d: UID cleared during toolhead transition; "
@@ -374,6 +410,28 @@ class SpoolLink:
         has_refresh_evidence = (
             eventtime > 0.
             and eventtime <= max(refresh_deadline, metadata_deadline))
+        known = self._known_spools.get(ch)
+        known_id = (
+            known[1].get("id", 0) if known is not None else 0) or 0
+        feeder_eligible = self._feeder_eligible.get(ch, False)
+        sensor_evidence = self._has_sensor_refresh_evidence(ch, eventtime)
+        feeder_state, feeder_action = self._feeder_load_states.get(
+            ch, (None, None))
+        logging.info(
+            "[spoollink] ch%d: spool clear decision: old_spool_id=%s "
+            "uid_present=%s uid_resolved=%s known_spool_id=%s "
+            "feeder_eligible=%s feeder_state=%s feeder_action=%s "
+            "sensor_evidence=%s sensor_window=%s reader_window=%s "
+            "metadata_window=%s toolhead_sensor=%s selected_toolhead=%s",
+            ch, old_spool_id, bool(uid),
+            bool(uid and self._resolved_uids.get(ch) == uid), known_id,
+            feeder_eligible, feeder_state, feeder_action, sensor_evidence,
+            self._deadline_remaining(
+                self._sensor_refresh_deadlines.get(ch, 0.), eventtime),
+            self._deadline_remaining(refresh_deadline, eventtime),
+            self._deadline_remaining(metadata_deadline, eventtime),
+            self._toolhead_sensors.get(ch, {}).get("filament_detected"),
+            self._extruder_to_channel(self._toolhead_extruder) == ch)
         if (uid and self._resolved_uids.get(ch) == uid
                 and has_refresh_evidence):
             self._refresh_deadlines.pop(ch, None)
@@ -385,10 +443,8 @@ class SpoolLink:
             self._schedule_detected_resolution(ch, uid)
             return
 
-        known = self._known_spools.get(ch)
-        known_id = (known[1].get("id", 0) if known is not None else 0) or 0
         if (not uid and known is not None and known_id == old_spool_id
-                and self._has_sensor_refresh_evidence(ch, eventtime)):
+                and sensor_evidence):
             self._sensor_refresh_deadlines.pop(ch, None)
             self._recovery_holds[ch] = (None, old_spool_id)
             logging.info(

--- a/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
@@ -131,11 +131,12 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
             },
         }, eventtime)
 
-    def set_toolhead_sensor(self, present, eventtime, channel=2):
+    def set_toolhead_sensor(
+            self, present, eventtime, channel=2, enabled=True):
         self.link._handle_status_update({
             f"filament_motion_sensor e{channel}_filament": {
                 "filament_detected": present,
-                "enabled": True,
+                "enabled": enabled,
             },
         }, eventtime)
 
@@ -144,16 +145,21 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         self.set_toolhead_sensor(True, 0.0, channel=channel)
         self.set_toolhead_sensor(False, eventtime, channel=channel)
 
-    def clear_uid_and_spool(self, eventtime=10.5, channel=2):
+    def clear_uid_and_spool(
+            self, eventtime=10.5, channel=2, clear_metadata=False):
         info = [None] * 4
         info[channel] = {"CARD_UID": 0}
+        ptc = {"filament_spool_id": [0, 0, 0, 0]}
+        if clear_metadata:
+            ptc.update({
+                "filament_vendor": ["NONE"] * 4,
+                "filament_type": ["NONE"] * 4,
+            })
         self.link._handle_status_update({
             "filament_detect": {
                 "info": info,
             },
-            "print_task_config": {
-                "filament_spool_id": [0, 0, 0, 0],
-            },
+            "print_task_config": ptc,
         }, eventtime)
 
     def start_reader_refresh(self, eventtime=10.0):
@@ -384,6 +390,89 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.link._ptc_spool_ids[2], 0)
         self.assertEqual(self.link._active_spool_id, 0)
         self.assertNotIn(2, self.link._known_spools)
+
+    async def test_load_heating_combined_clear_recovers_after_sensor_window(self):
+        self.prime_spool_27()
+        self.set_feeder(
+            channel_state="load_heating",
+            channel_action_state="load_heating")
+        self.set_toolhead_sensor(False, 0.0)
+        self.set_toolhead_sensor(True, 10.0)
+
+        with self.assertLogs(level="INFO") as captured:
+            self.clear_uid_and_spool(
+                eventtime=16.519, clear_metadata=True)
+        await self.drain(10)
+
+        messages = "\n".join(captured.output)
+        self.assertIn(
+            "sensor_evidence=False sensor_window=-1.519s "
+            "toolhead_sensor=True selected_toolhead=True "
+            "retained_restore=False load_clear_evidence=True",
+            messages)
+        self.assertIn(
+            "automatic read lost UID; restoring spool 27",
+            messages)
+        self.assertEqual(self.link._spoollink_set.await_count, 1)
+        self.assertEqual(self.link._ptc_spool_ids[2], 27)
+        self.assertEqual(self.link._active_spool_id, 27)
+        self.assertNotIn(None, self.config.server.spoolman.calls)
+        self.assertIn(2, self.link._known_spools)
+
+    async def test_combined_clear_requires_all_load_guards(self):
+        cases = (
+            ("finished load", {
+                "state": "load_finish", "action": "load_finish"}),
+            ("unknown load", {"state": None, "action": None}),
+            ("mismatched action", {"action": "load_finish"}),
+            ("sensor absent", {"sensor_present": False}),
+            ("sensor disabled", {"sensor_enabled": False}),
+            ("other toolhead", {"selected_toolhead": False}),
+            ("metadata retained", {"clear_metadata": False}),
+            ("automatic load disabled", {"disable_auto": True}),
+            ("known spool mismatch", {"known_spool_id": 31}),
+        )
+        for name, overrides in cases:
+            with self.subTest(name=name):
+                self.setUp()
+                self.prime_spool_27()
+                options = {
+                    "state": "load_heating",
+                    "action": "load_heating",
+                    "sensor_present": True,
+                    "sensor_enabled": True,
+                    "selected_toolhead": True,
+                    "clear_metadata": True,
+                    "disable_auto": False,
+                    "known_spool_id": 27,
+                }
+                options.update(overrides)
+                if options["known_spool_id"] != 27:
+                    known_spool = dict(OLD_SPOOL)
+                    known_spool["id"] = options["known_spool_id"]
+                    self.link._known_spools[2] = (OLD_UID, known_spool)
+                self.set_feeder(
+                    channel_state=options["state"],
+                    channel_action_state=options["action"],
+                    disable_auto=options["disable_auto"])
+                self.set_toolhead_sensor(
+                    not options["sensor_present"], 0.0,
+                    enabled=options["sensor_enabled"])
+                self.set_toolhead_sensor(
+                    options["sensor_present"], 10.0,
+                    enabled=options["sensor_enabled"])
+                if not options["selected_toolhead"]:
+                    self.link._toolhead_extruder = "extruder"
+
+                self.clear_uid_and_spool(
+                    eventtime=16.519,
+                    clear_metadata=options["clear_metadata"])
+                await self.drain(6)
+
+                self.link._spoollink_set.assert_not_awaited()
+                self.assertEqual(self.link._ptc_spool_ids[2], 0)
+                self.assertEqual(self.link._active_spool_id, 0)
+                self.assertNotIn(2, self.link._known_spools)
 
     async def test_successful_uid_apply_caches_spool_for_continuity(self):
         result = await self.link._apply_spool(2, OLD_SPOOL, OLD_UID)

--- a/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import AsyncMock
+
+
+COMPONENT = (
+    Path(__file__).resolve().parents[1]
+    / "root/home/lava/moonraker/moonraker/components/spoollink.py")
+SPEC = importlib.util.spec_from_file_location("spoollink_component", COMPONENT)
+SPOOLLINK = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(SPOOLLINK)
+
+OLD_UID = "0C259367"
+NEW_UID = "A1B2C3D4"
+OLD_TAG = {
+    "CARD_UID": [0x0C, 0x25, 0x93, 0x67],
+    "VENDOR": "Bambu",
+    "MAIN_TYPE": "PLA",
+    "SUB_TYPE": "Basic",
+    "OFFICIAL": True,
+    "SKU": 123,
+}
+NEW_TAG = {
+    "CARD_UID": [0xA1, 0xB2, 0xC3, 0xD4],
+    "VENDOR": "Generic",
+    "MAIN_TYPE": "PETG",
+    "SUB_TYPE": "Basic",
+    "OFFICIAL": True,
+    "SKU": 456,
+}
+
+
+class FakeSpoolman:
+    def __init__(self):
+        self.calls = []
+
+    def set_active_spool(self, spool_id):
+        self.calls.append(spool_id)
+
+
+class FakeKlippyApis:
+    pass
+
+
+class FakeServer:
+    error = RuntimeError
+
+    def __init__(self):
+        self.spoolman = FakeSpoolman()
+
+    def lookup_component(self, name, default=None):
+        components = {
+            "http_client": object(),
+            "klippy_apis": FakeKlippyApis(),
+            "spoolman": self.spoolman,
+        }
+        return components.get(name, default)
+
+    def register_remote_method(self, *args):
+        pass
+
+    def register_event_handler(self, *args):
+        pass
+
+
+class FakeConfig:
+    def __init__(self):
+        self.server = FakeServer()
+
+    def get_server(self):
+        return self.server
+
+    def get(self, key, default=None):
+        return "http://spoolman.test" if key == "server" else default
+
+
+class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.config = FakeConfig()
+        self.link = SPOOLLINK.SpoolLink(self.config)
+
+    async def drain(self, cycles=6):
+        for _ in range(cycles):
+            await asyncio.sleep(0)
+
+    def prime_spool_27(self):
+        self.link._channel_uids[2] = OLD_UID
+        self.link._channel_signatures[2] = (
+            self.link._filament_signature(OLD_TAG))
+        self.link._resolved_uids[2] = OLD_UID
+        self.link._fd_states = [0, 0, 0, 0]
+        self.link._ptc_vendors = ["NONE", "NONE", "Bambu", "NONE"]
+        self.link._ptc_types = ["NONE", "NONE", "PLA", "NONE"]
+        self.link._ptc_spool_ids = [0, 0, 27, 0]
+        self.link._toolhead_extruder = "extruder2"
+        self.link._active_spool_id = 27
+
+    def start_reader_refresh(self, eventtime=10.0):
+        self.link._handle_status_update({
+            "filament_detect": {"state": [0, 0, 1, 0]},
+        }, eventtime)
+
+    def finish_reader_refresh(self, eventtime=11.0, info=None):
+        fd = {"state": [0, 0, 0, 0]}
+        if info is not None:
+            fd["info"] = [None, None, info]
+        self.link._handle_status_update({
+            "filament_detect": fd,
+            "print_task_config": {
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, eventtime)
+
+    def set_resolver(self, result, gate=None):
+        calls = []
+
+        async def resolve(channel, spool_id=None, card_uid=None,
+                          expected_uid=None):
+            calls.append((channel, card_uid, expected_uid))
+            if gate is not None:
+                await gate.wait()
+            return result
+
+        self.link._resolve_spool = resolve
+        return calls
+
+    async def test_first_card_read_resolves_once(self):
+        calls = self.set_resolver(27)
+        self.link._handle_status_update({
+            "filament_detect": {"info": [OLD_TAG]},
+        }, 1.0)
+        await self.drain()
+        self.assertEqual(calls, [(0, OLD_UID, OLD_UID)])
+
+    async def test_unchanged_valid_uid_does_not_resolve(self):
+        self.prime_spool_27()
+        calls = self.set_resolver(27)
+        self.link._handle_status_update({
+            "filament_detect": {"info": [None, None, OLD_TAG]},
+        }, 5.0)
+        await self.drain()
+        self.assertEqual(calls, [])
+
+    async def test_reader_refresh_recovers_once_and_holds_active_spool(self):
+        self.prime_spool_27()
+        gate = asyncio.Event()
+        calls = self.set_resolver(27, gate)
+
+        self.start_reader_refresh()
+        # A hardware read can remain active longer than the recovery window;
+        # freshness is measured from completion, not from reader start.
+        self.finish_reader_refresh(30.0)
+        await self.drain(2)
+
+        self.assertEqual(calls, [(2, OLD_UID, OLD_UID)])
+        self.assertEqual(self.link._active_spool_id, 27)
+        self.assertNotIn(None, self.config.server.spoolman.calls)
+
+        # Duplicate status updates must not launch another lookup.
+        self.finish_reader_refresh(30.5)
+        await self.drain(2)
+        self.assertEqual(len(calls), 1)
+
+        gate.set()
+        await self.drain()
+        self.assertEqual(self.link._ptc_spool_ids[2], 27)
+        self.assertEqual(self.link._active_spool_id, 27)
+        self.assertNotIn(None, self.config.server.spoolman.calls)
+
+    async def test_cleared_metadata_recovers_external_uid_only_reader(self):
+        self.prime_spool_27()
+        calls = self.set_resolver(27)
+        self.link._handle_status_update({
+            "print_task_config": {
+                "filament_vendor": ["NONE", "NONE", "NONE", "NONE"],
+                "filament_type": ["NONE", "NONE", "NONE", "NONE"],
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, 20.0)
+        await self.drain()
+        self.assertEqual(calls, [(2, OLD_UID, OLD_UID)])
+        self.assertEqual(self.link._ptc_spool_ids[2], 27)
+
+    async def test_manual_spool_id_clear_remains_cleared(self):
+        self.prime_spool_27()
+        calls = self.set_resolver(27)
+        self.link._handle_status_update({
+            "print_task_config": {
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, 20.0)
+        await self.drain()
+        self.assertEqual(calls, [])
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertEqual(self.config.server.spoolman.calls, [None])
+
+    async def test_different_tag_never_recovers_previous_uid(self):
+        self.prime_spool_27()
+        calls = self.set_resolver(31)
+        self.start_reader_refresh()
+        self.finish_reader_refresh(info=NEW_TAG)
+        await self.drain()
+        self.assertEqual(calls, [(2, NEW_UID, NEW_UID)])
+        self.assertEqual(self.link._resolved_uids.get(2), NEW_UID)
+        self.assertEqual(self.link._ptc_spool_ids[2], 31)
+
+    async def test_stale_async_result_is_discarded_and_latest_uid_is_queued(self):
+        self.prime_spool_27()
+        old_gate = asyncio.Event()
+        calls = []
+
+        async def resolve(channel, spool_id=None, card_uid=None,
+                          expected_uid=None):
+            calls.append(card_uid)
+            if card_uid == OLD_UID:
+                await old_gate.wait()
+                return 27
+            return 31
+
+        self.link._resolve_spool = resolve
+        self.start_reader_refresh()
+        self.finish_reader_refresh()
+        await self.drain(2)
+
+        self.link._handle_status_update({
+            "filament_detect": {"info": [None, None, NEW_TAG]},
+        }, 12.0)
+        await self.drain(2)
+        self.assertEqual(calls, [OLD_UID])
+
+        old_gate.set()
+        await self.drain(10)
+        self.assertEqual(calls, [OLD_UID, NEW_UID])
+        self.assertEqual(self.link._resolved_uids.get(2), NEW_UID)
+        self.assertEqual(self.link._ptc_spool_ids[2], 31)
+
+    async def test_failed_recovery_releases_active_spool_hold(self):
+        self.prime_spool_27()
+        calls = self.set_resolver(None)
+        self.start_reader_refresh()
+        self.finish_reader_refresh()
+        await self.drain()
+        self.assertEqual(calls, [(2, OLD_UID, OLD_UID)])
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertEqual(self.config.server.spoolman.calls, [None])
+
+    async def test_tag_removal_releases_hold_and_stale_result_cannot_restore(self):
+        self.prime_spool_27()
+        gate = asyncio.Event()
+        calls = self.set_resolver(27, gate)
+        self.start_reader_refresh()
+        self.finish_reader_refresh()
+        await self.drain(2)
+
+        self.link._handle_status_update({
+            "filament_detect": {
+                "info": [None, None, {"CARD_UID": 0}],
+            },
+        }, 12.0)
+        await self.drain(2)
+        self.assertEqual(self.link._active_spool_id, 0)
+
+        gate.set()
+        await self.drain()
+        self.assertNotEqual(self.link._ptc_spool_ids[2], 27)
+        self.assertNotIn(2, self.link._resolved_uids)
+
+    async def test_resolve_checks_expected_uid_before_apply(self):
+        self.link._channel_uids[2] = OLD_UID
+        spool = {"id": 27, "filament": {}}
+
+        async def find_and_replace_tag(card_uid):
+            self.link._channel_uids[2] = NEW_UID
+            return [spool]
+
+        self.link._spoolman_find_by_card = find_and_replace_tag
+        self.link._apply_spool = AsyncMock(return_value=27)
+        result = await self.link._resolve_spool(
+            2, card_uid=OLD_UID, expected_uid=OLD_UID)
+        self.assertIsNone(result)
+        self.link._apply_spool.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
@@ -33,6 +33,15 @@ NEW_TAG = {
     "OFFICIAL": True,
     "SKU": 456,
 }
+OLD_SPOOL = {
+    "id": 27,
+    "filament": {
+        "material": "PLA",
+        "vendor": {"name": "Bambu"},
+        "color_hex": "009BD8",
+        "extra": {"variant": '"Tough+"'},
+    },
+}
 
 
 class FakeSpoolman:
@@ -83,22 +92,65 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.config = FakeConfig()
         self.link = SPOOLLINK.SpoolLink(self.config)
+        self.link._spoollink_set = AsyncMock(return_value={})
 
     async def drain(self, cycles=6):
         for _ in range(cycles):
             await asyncio.sleep(0)
 
-    def prime_spool_27(self):
-        self.link._channel_uids[2] = OLD_UID
-        self.link._channel_signatures[2] = (
+    def prime_spool_27(self, channel=2):
+        self.link._channel_uids[channel] = OLD_UID
+        self.link._channel_signatures[channel] = (
             self.link._filament_signature(OLD_TAG))
-        self.link._resolved_uids[2] = OLD_UID
+        self.link._resolved_uids[channel] = OLD_UID
+        self.link._known_spools[channel] = (OLD_UID, OLD_SPOOL)
         self.link._fd_states = [0, 0, 0, 0]
-        self.link._ptc_vendors = ["NONE", "NONE", "Bambu", "NONE"]
-        self.link._ptc_types = ["NONE", "NONE", "PLA", "NONE"]
-        self.link._ptc_spool_ids = [0, 0, 27, 0]
-        self.link._toolhead_extruder = "extruder2"
+        self.link._ptc_vendors = ["NONE"] * 4
+        self.link._ptc_vendors[channel] = "Bambu"
+        self.link._ptc_types = ["NONE"] * 4
+        self.link._ptc_types[channel] = "PLA"
+        self.link._ptc_spool_ids = [0] * 4
+        self.link._ptc_spool_ids[channel] = 27
+        self.link._toolhead_extruder = f"extruder{channel}"
         self.link._active_spool_id = 27
+
+    def set_feeder(self, present=True, module_exist=True,
+                   disable_auto=False, eventtime=0.0, channel=2):
+        side = "left" if channel < 2 else "right"
+        self.link._handle_status_update({
+            f"filament_feed {side}": {
+                f"extruder{channel}": {
+                    "module_exist": module_exist,
+                    "filament_detected": present,
+                    "disable_auto": disable_auto,
+                },
+            },
+        }, eventtime)
+
+    def set_toolhead_sensor(self, present, eventtime, channel=2):
+        self.link._handle_status_update({
+            f"filament_motion_sensor e{channel}_filament": {
+                "filament_detected": present,
+                "enabled": True,
+            },
+        }, eventtime)
+
+    def qualify_automatic_refresh(self, eventtime=10.0, channel=2):
+        self.set_feeder(eventtime=0.0, channel=channel)
+        self.set_toolhead_sensor(True, 0.0, channel=channel)
+        self.set_toolhead_sensor(False, eventtime, channel=channel)
+
+    def clear_uid_and_spool(self, eventtime=10.5, channel=2):
+        info = [None] * 4
+        info[channel] = {"CARD_UID": 0}
+        self.link._handle_status_update({
+            "filament_detect": {
+                "info": info,
+            },
+            "print_task_config": {
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, eventtime)
 
     def start_reader_refresh(self, eventtime=10.0):
         self.link._handle_status_update({
@@ -198,6 +250,7 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(calls, [])
         self.assertEqual(self.link._active_spool_id, 0)
         self.assertEqual(self.config.server.spoolman.calls, [None])
+        self.assertNotIn(2, self.link._known_spools)
 
     async def test_different_tag_never_recovers_previous_uid(self):
         self.prime_spool_27()
@@ -284,6 +337,264 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
             2, card_uid=OLD_UID, expected_uid=OLD_UID)
         self.assertIsNone(result)
         self.link._apply_spool.assert_not_awaited()
+
+    async def test_sensor_qualified_uid_loss_restores_cached_spool_and_holds_active(self):
+        self.prime_spool_27(channel=3)
+        self.qualify_automatic_refresh(channel=3)
+
+        self.clear_uid_and_spool(channel=3)
+        await self.drain(10)
+
+        self.assertEqual(self.link._ptc_spool_ids[3], 27)
+        self.assertEqual(self.link._active_spool_id, 27)
+        self.assertNotIn(None, self.config.server.spoolman.calls)
+        self.assertIn(3, self.link._known_spools)
+
+    async def test_successful_uid_apply_caches_spool_for_continuity(self):
+        result = await self.link._apply_spool(2, OLD_SPOOL, OLD_UID)
+
+        self.assertEqual(result, 27)
+        self.assertEqual(self.link._known_spools[2], (OLD_UID, OLD_SPOOL))
+
+    async def test_failed_uid_apply_does_not_cache_spool(self):
+        self.link._spoollink_set = AsyncMock(return_value=None)
+
+        result = await self.link._apply_spool(2, OLD_SPOOL, OLD_UID)
+
+        self.assertIsNone(result)
+        self.assertNotIn(2, self.link._known_spools)
+
+    async def test_retained_restore_does_not_invent_card_uid(self):
+        self.prime_spool_27()
+        self.qualify_automatic_refresh()
+
+        async def echo_set(channel, message, info=None, status="ok"):
+            self.link._handle_status_update({
+                "filament_detect": {"info": [None, None, info]},
+                "print_task_config": {
+                    "filament_spool_id": [0, 0, 27, 0],
+                },
+            }, 10.6)
+            return {}
+
+        self.link._spoollink_set = AsyncMock(side_effect=echo_set)
+
+        self.clear_uid_and_spool()
+        await self.drain(10)
+
+        calls = self.link._spoollink_set.await_args_list
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].kwargs["info"]["CARD_UID"], [])
+        self.assertEqual(calls[0].kwargs["info"]["SPOOL_ID"], 27)
+        self.assertIn(2, self.link._known_spools)
+
+    async def test_repeated_automatic_uid_loss_restores_once_per_transition(self):
+        self.prime_spool_27()
+        self.qualify_automatic_refresh()
+        self.clear_uid_and_spool()
+        await self.drain(10)
+
+        self.set_toolhead_sensor(True, 20.0)
+        self.link._handle_status_update({
+            "print_task_config": {
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, 20.5)
+        await self.drain(10)
+
+        self.assertEqual(self.link._spoollink_set.await_count, 2)
+        self.assertEqual(self.link._ptc_spool_ids[2], 27)
+        self.assertNotIn(None, self.config.server.spoolman.calls)
+
+    async def test_sensor_evidence_is_consumed_after_restore(self):
+        self.prime_spool_27()
+        self.qualify_automatic_refresh()
+        self.clear_uid_and_spool()
+        await self.drain(10)
+
+        self.clear_uid_and_spool(eventtime=11.0)
+        await self.drain(10)
+
+        self.assertEqual(self.link._spoollink_set.await_count, 1)
+        self.assertEqual(self.link._ptc_spool_ids[2], 0)
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertEqual(self.config.server.spoolman.calls, [None])
+        self.assertNotIn(2, self.link._known_spools)
+
+    async def test_duplicate_empty_uid_update_does_not_cancel_or_repeat_restore(self):
+        self.prime_spool_27()
+        self.qualify_automatic_refresh()
+        gate = asyncio.Event()
+
+        async def delayed_set(*args, **kwargs):
+            await gate.wait()
+            return {}
+
+        self.link._spoollink_set = AsyncMock(side_effect=delayed_set)
+        self.clear_uid_and_spool()
+        await self.drain(2)
+
+        self.clear_uid_and_spool(eventtime=10.6)
+        await self.drain(2)
+
+        self.assertEqual(self.link._spoollink_set.await_count, 1)
+        self.assertIn(2, self.link._known_spools)
+        self.assertEqual(self.link._recovery_holds.get(2), (None, 27))
+
+        gate.set()
+        await self.drain(6)
+        self.assertEqual(self.link._ptc_spool_ids[2], 27)
+        self.assertEqual(self.link._active_spool_id, 27)
+
+    async def test_failed_retained_restore_releases_hold_and_forgets_spool(self):
+        self.prime_spool_27()
+        self.qualify_automatic_refresh()
+        self.link._spoollink_set = AsyncMock(return_value=None)
+
+        self.clear_uid_and_spool()
+        await self.drain(10)
+
+        self.assertEqual(self.link._ptc_spool_ids[2], 0)
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertEqual(self.config.server.spoolman.calls, [None])
+        self.assertNotIn(2, self.link._known_spools)
+        self.assertNotIn(2, self.link._recovery_holds)
+
+    async def test_same_uid_return_keeps_hold_until_resolution_finishes(self):
+        self.prime_spool_27()
+        self.qualify_automatic_refresh()
+        restore_gate = asyncio.Event()
+
+        async def delayed_set(*args, **kwargs):
+            await restore_gate.wait()
+            return {}
+
+        self.link._spoollink_set = AsyncMock(side_effect=delayed_set)
+        self.clear_uid_and_spool()
+        await self.drain(2)
+
+        resolve_gate = asyncio.Event()
+        calls = self.set_resolver(27, resolve_gate)
+        self.link._handle_status_update({
+            "filament_detect": {"info": [None, None, OLD_TAG]},
+        }, 10.7)
+        await self.drain(2)
+
+        self.assertEqual(calls, [(2, OLD_UID, OLD_UID)])
+        self.assertEqual(self.link._active_spool_id, 27)
+        self.assertNotIn(None, self.config.server.spoolman.calls)
+
+        resolve_gate.set()
+        await self.drain(6)
+        self.assertEqual(self.link._ptc_spool_ids[2], 27)
+        self.assertEqual(self.link._active_spool_id, 27)
+
+    async def test_feeder_removal_cancels_pending_retained_restore(self):
+        self.prime_spool_27()
+        self.qualify_automatic_refresh()
+        gate = asyncio.Event()
+
+        async def delayed_set(*args, **kwargs):
+            await gate.wait()
+            return {}
+
+        self.link._spoollink_set = AsyncMock(side_effect=delayed_set)
+        self.clear_uid_and_spool()
+        await self.drain(2)
+
+        self.set_feeder(present=False, eventtime=11.0)
+        await self.drain(4)
+        gate.set()
+        await self.drain(4)
+
+        self.assertEqual(self.link._ptc_spool_ids[2], 0)
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertNotIn(2, self.link._known_spools)
+        self.assertNotIn(2, self.link._retention_tasks)
+
+    async def test_different_uid_cancels_retained_spool(self):
+        self.prime_spool_27()
+        self.qualify_automatic_refresh()
+        self.clear_uid_and_spool()
+        await self.drain(10)
+        calls = self.set_resolver(31)
+
+        self.link._handle_status_update({
+            "filament_detect": {"info": [None, None, NEW_TAG]},
+        }, 12.0)
+        await self.drain(10)
+
+        self.assertEqual(calls, [(2, NEW_UID, NEW_UID)])
+        self.assertNotIn(2, self.link._known_spools)
+
+    async def test_unqualified_feeder_never_retains_spool(self):
+        invalid_states = (
+            (False, True, False),
+            (True, False, False),
+            (True, True, True),
+        )
+        for module_exist, present, disable_auto in invalid_states:
+            with self.subTest(module_exist=module_exist, present=present,
+                              disable_auto=disable_auto):
+                self.setUp()
+                self.prime_spool_27()
+                self.set_feeder(
+                    present=present,
+                    module_exist=module_exist,
+                    disable_auto=disable_auto,
+                    eventtime=0.0)
+                self.set_toolhead_sensor(True, 0.0)
+                self.set_toolhead_sensor(False, 10.0)
+
+                self.clear_uid_and_spool()
+                await self.drain(6)
+
+                self.assertEqual(self.link._spoollink_set.await_count, 0)
+                self.assertEqual(self.link._ptc_spool_ids[2], 0)
+                self.assertNotIn(2, self.link._known_spools)
+
+    async def test_disabled_or_other_toolhead_sensor_never_qualifies_channel(self):
+        updates = (
+            {"filament_motion_sensor e2_filament": {
+                "filament_detected": False, "enabled": False}},
+            {"filament_motion_sensor e1_filament": {
+                "filament_detected": False, "enabled": True}},
+        )
+        for update in updates:
+            with self.subTest(update=update):
+                self.setUp()
+                self.prime_spool_27()
+                self.set_feeder(eventtime=0.0)
+                self.set_toolhead_sensor(True, 0.0)
+                self.link._handle_status_update(update, 10.0)
+
+                self.clear_uid_and_spool()
+                await self.drain(6)
+
+                self.assertEqual(self.link._spoollink_set.await_count, 0)
+                self.assertEqual(self.link._ptc_spool_ids[2], 0)
+                self.assertNotIn(2, self.link._known_spools)
+
+    async def test_disconnect_clears_retained_state_and_tasks(self):
+        self.prime_spool_27()
+        self.qualify_automatic_refresh()
+        gate = asyncio.Event()
+
+        async def delayed_set(*args, **kwargs):
+            await gate.wait()
+            return {}
+
+        self.link._spoollink_set = AsyncMock(side_effect=delayed_set)
+        self.clear_uid_and_spool()
+        await self.drain(2)
+
+        self.link._handle_klippy_disconnect()
+        await self.drain(4)
+
+        self.assertEqual(self.link._known_spools, {})
+        self.assertEqual(self.link._retention_tasks, {})
+        self.assertEqual(self.link._feeder_eligible, {})
+        self.assertEqual(self.link._toolhead_sensors, {})
 
 
 if __name__ == "__main__":

--- a/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
@@ -205,7 +205,8 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         calls = []
 
         async def resolve(channel, spool_id=None, card_uid=None,
-                          expected_uid=None):
+                          expected_uid=None,
+                          expected_card_event_time=None):
             calls.append((channel, card_uid, expected_uid))
             if gate is not None:
                 await gate.wait()
@@ -230,6 +231,148 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         }, 5.0)
         await self.drain()
         self.assertEqual(calls, [])
+
+    async def test_same_uid_card_event_resolves_and_holds_active_spool(self):
+        self.prime_spool_27()
+        gate = asyncio.Event()
+        calls = self.set_resolver(27, gate)
+        info = dict(OLD_TAG, CARD_EVENT_TIME=100.25)
+
+        self.link._handle_status_update({
+            "filament_detect": {"info": [None, None, info]},
+            "print_task_config": {
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, 10.0)
+        await self.drain(2)
+
+        self.assertEqual(calls, [(2, OLD_UID, OLD_UID)])
+        self.assertEqual(self.link._active_spool_id, 27)
+        self.assertEqual(self.link._recovery_holds.get(2), (OLD_UID, 27))
+        self.assertNotIn(None, self.config.server.spoolman.calls)
+
+        gate.set()
+        await self.drain(8)
+        self.assertEqual(self.link._ptc_spool_ids[2], 27)
+        self.assertEqual(self.link._active_spool_id, 27)
+        self.assertNotIn(None, self.config.server.spoolman.calls)
+
+    async def test_duplicate_and_older_card_events_are_ignored(self):
+        self.prime_spool_27()
+        self.link._channel_event_times[2] = 100.25
+        calls = self.set_resolver(27)
+
+        for card_event_time in (100.25, 100.0):
+            info = dict(OLD_TAG, CARD_EVENT_TIME=card_event_time)
+            self.link._handle_status_update({
+                "filament_detect": {"info": [None, None, info]},
+            }, 10.0)
+        await self.drain()
+        self.assertEqual(calls, [])
+
+        info = dict(OLD_TAG, CARD_EVENT_TIME=100.5)
+        self.link._handle_status_update({
+            "filament_detect": {"info": [None, None, info]},
+        }, 10.1)
+        await self.drain()
+        self.assertEqual(calls, [(2, OLD_UID, OLD_UID)])
+
+    async def test_newer_same_uid_event_supersedes_inflight_resolution(self):
+        self.prime_spool_27()
+        gate = asyncio.Event()
+        calls = []
+
+        async def resolve(channel, spool_id=None, card_uid=None,
+                          expected_uid=None,
+                          expected_card_event_time=None):
+            calls.append(expected_card_event_time)
+            if expected_card_event_time == 100.25:
+                await gate.wait()
+            return 27
+
+        self.link._resolve_spool = resolve
+        first = dict(OLD_TAG, CARD_EVENT_TIME=100.25)
+        second = dict(OLD_TAG, CARD_EVENT_TIME=100.5)
+        self.link._handle_status_update({
+            "filament_detect": {"info": [None, None, first]},
+        }, 10.0)
+        await self.drain(2)
+        self.link._handle_status_update({
+            "filament_detect": {"info": [None, None, second]},
+        }, 10.1)
+        await self.drain(2)
+        self.assertEqual(calls, [100.25])
+
+        gate.set()
+        await self.drain(10)
+        self.assertEqual(calls, [100.25, 100.5])
+        self.assertEqual(self.link._resolved_uids.get(2), OLD_UID)
+        self.assertEqual(self.link._ptc_spool_ids[2], 27)
+        self.assertNotIn(None, self.config.server.spoolman.calls)
+
+    async def test_manual_clear_cancels_inflight_card_event_resolution(self):
+        self.prime_spool_27()
+        gate = asyncio.Event()
+        calls = self.set_resolver(27, gate)
+        info = dict(OLD_TAG, CARD_EVENT_TIME=100.25)
+        self.link._handle_status_update({
+            "filament_detect": {"info": [None, None, info]},
+        }, 10.0)
+        await self.drain(2)
+
+        self.link._handle_status_update({
+            "print_task_config": {
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, 15.001)
+        await self.drain(6)
+
+        self.assertEqual(calls, [(2, OLD_UID, OLD_UID)])
+        self.assertEqual(self.link._resolution_tasks, {})
+        self.assertEqual(self.link._ptc_spool_ids[2], 0)
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertEqual(self.config.server.spoolman.calls, [None])
+
+        gate.set()
+        await self.drain(4)
+        self.assertEqual(self.link._ptc_spool_ids[2], 0)
+
+    async def test_empty_card_event_cancels_external_resolution(self):
+        self.configure_link("3")
+        self.prime_spool_27(channel=3)
+        gate = asyncio.Event()
+        calls = self.set_resolver(27, gate)
+        present = dict(OLD_TAG, CARD_EVENT_TIME=100.25)
+        self.link._handle_status_update({
+            "filament_detect": {
+                "info": [None, None, None, present],
+            },
+        }, 10.0)
+        await self.drain(2)
+
+        self.link._handle_status_update({
+            "filament_detect": {
+                "info": [None, None, None, {
+                    "CARD_UID": 0,
+                    "CARD_EVENT_TIME": 100.5,
+                }],
+            },
+            "print_task_config": {
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, 10.1)
+        await self.drain(6)
+
+        self.assertEqual(calls, [(3, OLD_UID, OLD_UID)])
+        self.assertEqual(self.link._resolution_tasks, {})
+        self.assertEqual(self.link._ptc_spool_ids[3], 0)
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertEqual(self.config.server.spoolman.calls, [None])
+        self.assertNotIn(3, self.link._known_spools)
+
+        gate.set()
+        await self.drain(4)
+        self.assertEqual(self.link._ptc_spool_ids[3], 0)
 
     def test_external_channel_configuration_defaults_and_normalizes(self):
         self.assertEqual(self.link._external_channels, set())
@@ -315,7 +458,8 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         self.link._toolhead_extruder = "extruder3"
 
         async def resolve(channel, spool_id=None, card_uid=None,
-                          expected_uid=None):
+                          expected_uid=None,
+                          expected_card_event_time=None):
             return await self.link._apply_spool(
                 channel, OLD_SPOOL, card_uid or "")
 
@@ -413,6 +557,7 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(self.link._known_spools, {})
         self.assertEqual(self.link._resolved_uids, {})
+        self.assertEqual(self.link._channel_event_times, {})
         self.assertEqual(self.link._refresh_deadlines, {})
         self.assertEqual(self.link._feeder_eligible, {})
         self.assertEqual(self.link._external_channels, {3})
@@ -496,7 +641,8 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         calls = []
 
         async def resolve(channel, spool_id=None, card_uid=None,
-                          expected_uid=None):
+                          expected_uid=None,
+                          expected_card_event_time=None):
             calls.append(card_uid)
             if card_uid == OLD_UID:
                 await old_gate.wait()
@@ -563,6 +709,23 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         self.link._apply_spool = AsyncMock(return_value=27)
         result = await self.link._resolve_spool(
             2, card_uid=OLD_UID, expected_uid=OLD_UID)
+        self.assertIsNone(result)
+        self.link._apply_spool.assert_not_awaited()
+
+    async def test_resolve_checks_expected_card_event_before_apply(self):
+        self.link._channel_uids[2] = OLD_UID
+        self.link._channel_event_times[2] = 100.25
+        spool = {"id": 27, "filament": {}}
+
+        async def find_after_newer_event(card_uid):
+            self.link._channel_event_times[2] = 100.5
+            return [spool]
+
+        self.link._spoolman_find_by_card = find_after_newer_event
+        self.link._apply_spool = AsyncMock(return_value=27)
+        result = await self.link._resolve_spool(
+            2, card_uid=OLD_UID, expected_uid=OLD_UID,
+            expected_card_event_time=100.25)
         self.assertIsNone(result)
         self.link._apply_spool.assert_not_awaited()
 
@@ -935,6 +1098,8 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(self.link._known_spools, {})
         self.assertEqual(self.link._retention_tasks, {})
+        self.assertEqual(self.link._channel_event_times, {})
+        self.assertEqual(self.link._resolution_task_event_times, {})
         self.assertEqual(self.link._feeder_eligible, {})
         self.assertEqual(self.link._toolhead_sensors, {})
 

--- a/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
@@ -78,19 +78,42 @@ class FakeServer:
 
 
 class FakeConfig:
-    def __init__(self):
+    error = RuntimeError
+
+    def __init__(self, external_channels=None):
         self.server = FakeServer()
+        self.options = {
+            "server": "http://spoolman.test",
+            "external_channels": external_channels,
+        }
 
     def get_server(self):
         return self.server
 
     def get(self, key, default=None):
-        return "http://spoolman.test" if key == "server" else default
+        value = self.options.get(key)
+        return default if value is None else value
+
+    def getintlist(self, key, default=None, separator="\n"):
+        value = self.options.get(key)
+        if value is None:
+            return default
+        try:
+            return [
+                int(item.strip()) for item in value.split(separator)
+                if item.strip()
+            ]
+        except (AttributeError, ValueError) as e:
+            raise self.error(
+                f"invalid integer list for {key}: {value}") from e
 
 
 class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        self.config = FakeConfig()
+        self.configure_link()
+
+    def configure_link(self, external_channels=None):
+        self.config = FakeConfig(external_channels)
         self.link = SPOOLLINK.SpoolLink(self.config)
         self.link._spoollink_set = AsyncMock(return_value={})
 
@@ -207,6 +230,201 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         }, 5.0)
         await self.drain()
         self.assertEqual(calls, [])
+
+    def test_external_channel_configuration_defaults_and_normalizes(self):
+        self.assertEqual(self.link._external_channels, set())
+
+        configured = SPOOLLINK.SpoolLink(FakeConfig("3, 1, 3"))
+
+        self.assertEqual(configured._external_channels, {1, 3})
+
+    def test_external_channel_configuration_rejects_invalid_values(self):
+        for value in ("-1", "4", "1,4", "invalid"):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                        RuntimeError, "external_channels"):
+                    SPOOLLINK.SpoolLink(FakeConfig(value))
+
+    async def test_startup_logs_configured_external_channels(self):
+        self.configure_link("3,1")
+        self.link._ensure_fields = AsyncMock()
+
+        with self.assertLogs(level="INFO") as captured:
+            await self.link.component_init()
+
+        self.assertIn(
+            "external channels: [1, 3]", "\n".join(captured.output))
+
+    async def test_configured_external_feeder_loss_retains_current_spool(self):
+        self.configure_link("3")
+        self.prime_spool_27(channel=3)
+        self.set_feeder(channel=3)
+
+        with self.assertLogs(level="INFO") as captured:
+            self.set_feeder(
+                present=False, module_exist=False,
+                eventtime=1.0, channel=3)
+
+        self.assertEqual(
+            self.link._known_spools.get(3), (OLD_UID, OLD_SPOOL))
+        self.assertEqual(self.link._resolved_uids.get(3), OLD_UID)
+        messages = "\n".join(captured.output)
+        self.assertIn("external_channel=True", messages)
+        self.assertIn("module_exist=False", messages)
+        self.assertIn("filament_detected=False", messages)
+        self.assertIn("disable_auto=False", messages)
+        self.assertIn("retain_known_spool=True", messages)
+
+    async def test_external_feeder_loss_requires_current_resolved_spool(self):
+        cases = ("empty UID", "unresolved UID", "known UID mismatch")
+        for case in cases:
+            with self.subTest(case=case):
+                self.configure_link("3")
+                self.prime_spool_27(channel=3)
+                self.set_feeder(channel=3)
+                if case == "empty UID":
+                    self.link._channel_uids[3] = ""
+                elif case == "unresolved UID":
+                    self.link._resolved_uids.pop(3)
+                else:
+                    self.link._known_spools[3] = (NEW_UID, OLD_SPOOL)
+
+                self.set_feeder(
+                    present=False, module_exist=False,
+                    eventtime=1.0, channel=3)
+
+                self.assertNotIn(3, self.link._known_spools)
+                self.assertNotIn(3, self.link._resolved_uids)
+
+    async def test_unconfigured_feeder_loss_forgets_current_spool(self):
+        self.prime_spool_27(channel=3)
+        self.set_feeder(channel=3)
+
+        self.set_feeder(
+            present=False, module_exist=False,
+            eventtime=1.0, channel=3)
+
+        self.assertNotIn(3, self.link._known_spools)
+        self.assertNotIn(3, self.link._resolved_uids)
+
+    async def test_continuously_ineligible_external_channel_recovers(self):
+        self.configure_link("3")
+        self.set_feeder(
+            present=False, module_exist=False,
+            eventtime=0.0, channel=3)
+        self.link._toolhead_extruder = "extruder3"
+
+        async def resolve(channel, spool_id=None, card_uid=None,
+                          expected_uid=None):
+            return await self.link._apply_spool(
+                channel, OLD_SPOOL, card_uid or "")
+
+        self.link._resolve_spool = resolve
+        self.link._handle_status_update({
+            "filament_detect": {
+                "info": [None, None, None, OLD_TAG],
+            },
+        }, 10.0)
+        await self.drain(8)
+        self.assertEqual(self.link._resolved_uids.get(3), OLD_UID)
+        self.assertEqual(
+            self.link._known_spools.get(3), (OLD_UID, OLD_SPOOL))
+        self.assertEqual(self.link._refresh_deadlines.get(3), 15.0)
+
+        self.link._active_spool_id = 27
+        self.config.server.spoolman.calls.clear()
+        self.link._handle_status_update({
+            "print_task_config": {
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, 10.5)
+        await self.drain(10)
+
+        self.assertEqual(self.link._ptc_spool_ids[3], 27)
+        self.assertEqual(self.link._active_spool_id, 27)
+        self.assertNotIn(None, self.config.server.spoolman.calls)
+
+    async def test_external_channel_empty_uid_is_always_a_release(self):
+        self.configure_link("3")
+        self.prime_spool_27(channel=3)
+        self.qualify_automatic_refresh(channel=3)
+
+        self.clear_uid_and_spool(
+            channel=3, clear_metadata=True)
+        await self.drain(8)
+
+        self.link._spoollink_set.assert_not_awaited()
+        self.assertEqual(self.link._ptc_spool_ids[3], 0)
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertNotIn(3, self.link._known_spools)
+
+    async def test_external_manual_clear_after_window_remains_cleared(self):
+        self.configure_link("3")
+        self.prime_spool_27(channel=3)
+        self.link._refresh_deadlines[3] = 15.0
+
+        self.link._handle_status_update({
+            "print_task_config": {
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, 15.001)
+        await self.drain(8)
+
+        self.link._spoollink_set.assert_not_awaited()
+        self.assertEqual(self.link._ptc_spool_ids[3], 0)
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertNotIn(3, self.link._known_spools)
+
+    async def test_external_failed_new_uid_resolution_never_restores_old(self):
+        self.configure_link("3")
+        self.prime_spool_27(channel=3)
+        calls = self.set_resolver(None)
+
+        self.link._handle_status_update({
+            "filament_detect": {
+                "info": [None, None, None, NEW_TAG],
+            },
+        }, 10.0)
+        await self.drain(8)
+        self.link._handle_status_update({
+            "print_task_config": {
+                "filament_spool_id": [0, 0, 0, 0],
+            },
+        }, 10.5)
+        await self.drain(8)
+
+        self.assertEqual(calls, [(3, NEW_UID, NEW_UID)])
+        self.assertEqual(self.link._ptc_spool_ids[3], 0)
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertNotIn(3, self.link._known_spools)
+        self.assertNotIn(3, self.link._resolved_uids)
+
+    async def test_external_disconnect_clears_only_runtime_state(self):
+        self.configure_link("3")
+        self.prime_spool_27(channel=3)
+        self.set_feeder(channel=3)
+        self.set_feeder(
+            present=False, module_exist=False,
+            eventtime=1.0, channel=3)
+        self.assertIn(3, self.link._known_spools)
+
+        self.link._handle_klippy_disconnect()
+        await self.drain(4)
+
+        self.assertEqual(self.link._known_spools, {})
+        self.assertEqual(self.link._resolved_uids, {})
+        self.assertEqual(self.link._refresh_deadlines, {})
+        self.assertEqual(self.link._feeder_eligible, {})
+        self.assertEqual(self.link._external_channels, {3})
+
+    async def test_channel_spool_overrides_manual_active_spool(self):
+        self.prime_spool_27(channel=3)
+
+        self.link._handle_active_spool_set({"spool_id": 99})
+        await self.drain(4)
+
+        self.assertEqual(self.link._active_spool_id, 27)
+        self.assertEqual(self.config.server.spoolman.calls, [27])
 
     async def test_reader_refresh_recovers_once_and_holds_active_spool(self):
         self.prime_spool_27()

--- a/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/test/test_spoollink.py
@@ -115,7 +115,9 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         self.link._active_spool_id = 27
 
     def set_feeder(self, present=True, module_exist=True,
-                   disable_auto=False, eventtime=0.0, channel=2):
+                   disable_auto=False, eventtime=0.0, channel=2,
+                   channel_state="load_finish",
+                   channel_action_state="load_finish"):
         side = "left" if channel < 2 else "right"
         self.link._handle_status_update({
             f"filament_feed {side}": {
@@ -123,6 +125,8 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
                     "module_exist": module_exist,
                     "filament_detected": present,
                     "disable_auto": disable_auto,
+                    "channel_state": channel_state,
+                    "channel_action_state": channel_action_state,
                 },
             },
         }, eventtime)
@@ -349,6 +353,37 @@ class SpoolLinkRecoveryTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.link._active_spool_id, 27)
         self.assertNotIn(None, self.config.server.spoolman.calls)
         self.assertIn(3, self.link._known_spools)
+
+    async def test_expired_sensor_window_logs_recovery_decision_inputs(self):
+        self.prime_spool_27()
+        self.set_feeder(
+            channel_state="loading",
+            channel_action_state="feed_to_extruder")
+        self.set_toolhead_sensor(True, 0.0)
+        self.set_toolhead_sensor(False, 10.0)
+
+        with self.assertLogs(level="INFO") as captured:
+            self.clear_uid_and_spool(eventtime=15.001)
+        await self.drain(6)
+
+        messages = "\n".join(captured.output)
+        self.assertIn(
+            "UID clear decision: known_spool_id=27 feeder_eligible=True "
+            "feeder_state=loading feeder_action=feed_to_extruder "
+            "sensor_evidence=False sensor_window=-0.001s "
+            "toolhead_sensor=False selected_toolhead=True "
+            "retained_restore=False",
+            messages)
+        self.assertIn(
+            "spool clear decision: old_spool_id=27 uid_present=False "
+            "uid_resolved=False known_spool_id=0 feeder_eligible=True "
+            "feeder_state=loading feeder_action=feed_to_extruder "
+            "sensor_evidence=False sensor_window=none",
+            messages)
+        self.link._spoollink_set.assert_not_awaited()
+        self.assertEqual(self.link._ptc_spool_ids[2], 0)
+        self.assertEqual(self.link._active_spool_id, 0)
+        self.assertNotIn(2, self.link._known_spools)
 
     async def test_successful_uid_apply_caches_spool_for_continuity(self):
         result = await self.link._apply_spool(2, OLD_SPOOL, OLD_UID)


### PR DESCRIPTION
## Summary

Prevent SpoolLink assignments from being lost when a U1 RFID refresh or automatic filament load temporarily clears `filament_spool_id`.

The existing recovery handles the case where the UID remains unchanged. This update also handles home-tagged spools whose UID becomes empty while loading to the toolhead.

The fallback is deliberately narrow. It requires the same feeder to remain present with automatic loading enabled and a recent transition from the corresponding toolhead filament sensor.

No public APIs, configuration fields, or data formats change.

## Implementation

- Recognize same-UID recovery only when fresh reader or metadata evidence confirms a refresh.
- Cache the last successfully resolved UID and Spoolman payload for each channel in memory.
- Restore cached metadata when a qualified automatic load clears both the UID and spool ID.
- Send `CARD_UID=[]` during that restore rather than inventing or rebinding a tag.
- Preserve the active Spoolman assignment while a validated recovery is running.
- Permit only one restore or resolution task per channel.
- Reject stale asynchronous results.
- Cancel retained state after feeder removal, a different UID, an unqualified clear, or Klippy disconnect.
- Do not poll or retry the RFID reader.

## Relationship to #622

This addresses the same underlying problem as #622 but uses guarded recovery state rather than triggering from cleared vendor or material fields.

The two recovery mechanisms should not be combined because both could schedule recovery for the same refresh.

Dragon2203 reported repeated reads and resolutions with #622 during print-start auto-load. He also found that its vendor-based trigger could interact with `force_generic_vendor` from #619 and leave a lane unresolved as Generic.

[Dragon2203's comparative hardware report](https://github.com/Ali-Jab/SnapmakerU1-Extended-Firmware/commit/7374e4eaf81f32885a390c86c73c3a76840b9fc8#commitcomment-197031392)

## Validation

### Ali

Initial idle validation:

- Channel 2, spool 27, UID `0C259367`.
- The channel spool ID changed `27 -> 0 -> 27`.
- The active Spoolman assignment remained 27.
- Recovery completed in approximately 1.18 seconds.
- The idle test did not change Spoolman usage fields.

Channel-3 automatic-load validation on 21 August 2026:

- Spool 28, UID `06A533EB`, recovered `28 -> 0 -> 28` in approximately 0.17 seconds.
- Spool 27, UID `0C259367`, recovered `27 -> 0 -> 27` in approximately 0.10 seconds.
- Each load caused one recovery.
- No repeated resolution occurred.
- The active Spoolman assignment did not become `None` during either recovery.
- Removing or replacing the spool cleared the previous assignment.
- A different UID did not inherit the previous spool.
- Spoolman remained connected with no pending usage reports.

The empty-UID fallback is covered by automated tests but was not triggered by Ali's RFID tags. External validation with a home-tagged spool is still required before this draft is marked ready.

### Dragon2203

- Tested print-start auto-load on two channels.
- Confirmed that the active assignment remained available to AFC and Home Assistant.
- Tested normal RFID detection, removal and reinsertion, and manual reassignment.
- Directly compared this implementation with #622.
- Tested a combined build containing #619 and #624 without observing conflicts. Those changes are not included in this PR.

### Automated checks

- 24 focused SpoolLink regression tests pass.
- Python bytecode compilation passes.
- `git diff --check` passes.
- All changed text files use LF line endings.
- The PR changes only `spoollink.py`, its test file, and the pull-request workflow.

## AI disclosure

The implementation and tests were developed with OpenAI Codex. Ali reviewed the changes and performed the physical printer validation.