### PR TITLE
Add `CARD_EVENT_TIME` and use it to trigger SpoolLink resolves

### DIFF
--- a/docs/design/filament_detect.md
+++ b/docs/design/filament_detect.md
@@ -41,6 +41,7 @@ Read-only fields (returned by query, not accepted by `set`):
 |---|---|
 | `ARGB_COLOR` | Derived: `(ALPHA << 24) \| RGB_1` |
 | `OFFICIAL` | `true` when `info` contains at least one filament field other than `CARD_UID` |
+| `CARD_EVENT_TIME` | `float`, `self.reactor.monotonic()` at the time this channel's record was last written, by `filament_detect/set` or a native M1/NTAG hardware read |
 | `MANUFACTURER` | |
 | `VERSION` | |
 | `TRAY` | |
@@ -295,6 +296,7 @@ Repository overlays:
 - `overlays/firmware-extended/13-patch-rfid/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py`
 - `overlays/firmware-extended/13-patch-rfid/patches/02-add-ndef-protocol.patch`
 - `overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch`
+- `overlays/firmware-extended/13-patch-rfid/patches/09-add-card-event-time.patch`
 - `overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg`
 
 Klipper source code:

--- a/overlays/firmware-extended/13-patch-rfid/README.md
+++ b/overlays/firmware-extended/13-patch-rfid/README.md
@@ -25,6 +25,10 @@ Patch set in `overlays/firmware-extended/13-rfid-support/patches`:
   - When M1 auth fails, sets `card_data` to the UID bytes from the anticollision/SELECT phase
     (`self.__picc_a.UID[0:4]`) so that `CARD_UID` and `CARD_TYPE` are still populated via the
     existing patch-07 handler in `filament_detect.py`.
+- `09-add-card-event-time.patch`
+  - Adds `CARD_EVENT_TIME` (`self.reactor.monotonic()`, `float`) to `FILAMENT_INFO_STRUCT`,
+    stamped in `_filament_info_update` and directly in `_handle_filament_detect_set` on every
+    write to a channel's record.
 
 ## API Contract
 

--- a/overlays/firmware-extended/13-patch-rfid/patches/09-add-card-event-time.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/09-add-card-event-time.patch
@@ -1,0 +1,28 @@
+--- rootfs.original/home/lava/klipper/klippy/extras/filament_protocol.py
++++ rootfs/home/lava/klipper/klippy/extras/filament_protocol.py
+@@ -36,6 +36,7 @@
+     'OFFICIAL': False,
+     'CARD_UID': 0,
+     'CARD_TYPE': '',
++    'CARD_EVENT_TIME': 0,
+ }
+ 
+ # Filament main type
+--- rootfs.original/home/lava/klipper/klippy/extras/filament_detect.py
++++ rootfs/home/lava/klipper/klippy/extras/filament_detect.py
+@@ -104,6 +104,7 @@
+ 
+ 
+     def _filament_info_update(self, channel, info, is_clear=False):
++        info['CARD_EVENT_TIME'] = self.reactor.monotonic()
+         self._filament_info[channel] = info
+ 
+         # notify
+@@ -251,6 +252,7 @@
+                 raise web_request.error("unsupported fields: %s" % (', '.join(sorted(params.keys()))))
+ 
+             filament_info['OFFICIAL'] = has_params
++            filament_info['CARD_EVENT_TIME'] = self.reactor.monotonic()
+             self._state[channel] = FILAMENT_DT_STATE_IDLE
+ 
+             ptc = self.printer.lookup_object('print_task_config', None)

--- a/overlays/firmware-extended/13-patch-rfid/test/filament_detect.py
+++ b/overlays/firmware-extended/13-patch-rfid/test/filament_detect.py
@@ -43,7 +43,8 @@ def cmd_get(host):
         if ch < len(fd_info):
             i = fd_info[ch]
             official = i.get("OFFICIAL", False)
-            print(f"  RFID:   {i.get('VENDOR','')} {i.get('MAIN_TYPE','')} {i.get('SUB_TYPE','')}  [official: {'yes' if official else 'no'}]")
+            event_time = i.get("CARD_EVENT_TIME", 0)
+            print(f"  RFID:   {i.get('VENDOR','')} {i.get('MAIN_TYPE','')} {i.get('SUB_TYPE','')}  [official: {'yes' if official else 'no'}, detected: {event_time:.3f}]")
         else:
             print("  RFID:   (no data)")
 

--- a/overlays/firmware-extended/13-patch-rfid/test/filament_detect_test.py
+++ b/overlays/firmware-extended/13-patch-rfid/test/filament_detect_test.py
@@ -171,6 +171,28 @@ def main():
     expect("RFID CARD_UID reset to struct default (0)")
     check("rfid.CARD_UID", rfid.get("CARD_UID"), 0)
 
+    section("Step 7: CARD_EVENT_TIME advances on every set, even sub-second and with unchanged fields")
+    reset(host)
+    op(f"set-rfid channel=0  {RFID_VENDOR} {RFID_TYPE} {RFID_SUBTYPE}  CARD_UID={RFID_CARD_UID}")
+    fd.cmd_set_rfid(host, 0, RFID_VENDOR, RFID_TYPE, RFID_SUBTYPE, RFID_COLOR, card_uid=RFID_CARD_UID)
+    rfid, ptc = get_state(host)
+    expect("CARD_EVENT_TIME stamped on first set")
+    first_event_time = rfid.get("CARD_EVENT_TIME")
+    check("rfid.CARD_EVENT_TIME > 0", first_event_time is not None and first_event_time > 0, True)
+    # Two detection events can land closer together than 1s apart; a whole-second value
+    # would make them indistinguishable and hide the second update, at any gap size.
+    time.sleep(0.2)
+    op(f"set-rfid channel=0  {RFID_VENDOR} {RFID_TYPE} {RFID_SUBTYPE}  CARD_UID={RFID_CARD_UID}  (same UID, same fields, 0.2s later)")
+    fd.cmd_set_rfid(host, 0, RFID_VENDOR, RFID_TYPE, RFID_SUBTYPE, RFID_COLOR, card_uid=RFID_CARD_UID)
+    rfid, ptc = get_state(host)
+    expect("CARD_EVENT_TIME advances within the same wall-clock second (sub-second precision)")
+    check("rfid.CARD_EVENT_TIME advanced", rfid.get("CARD_EVENT_TIME", 0) > first_event_time, True)
+    op("clear-rfid channel=0")
+    fd.cmd_clear_rfid(host, 0)
+    rfid, ptc = get_state(host)
+    expect("CARD_EVENT_TIME is still stamped on a clear (it marks detection activity, not tag content)")
+    check("rfid.CARD_EVENT_TIME > 0 after clear", rfid.get("CARD_EVENT_TIME", 0) > 0, True)
+
     print(f"\n{'OK' if _failures == 0 else 'FAILED'}  {_passes} passed, {_failures} failed")
     sys.exit(0 if _failures == 0 else 1)
 

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
@@ -55,7 +55,7 @@ class SpoolLink:
         self.http_client: HttpClient = self.server.lookup_component("http_client")
         self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
 
-        self._channel_uids: Dict[int, str] = {}
+        self._channel_event_times: Dict[int, float] = {}
         self._toolhead_extruder: str = "extruder"
         self._ptc_spool_ids: List[int] = []
         self._active_spool_id: Optional[int] = None
@@ -87,7 +87,7 @@ class SpoolLink:
 
     def _handle_klippy_disconnect(self) -> None:
         logging.info("[spoollink] Klippy disconnected")
-        self._channel_uids = {}
+        self._channel_event_times = {}
         self._ptc_spool_ids = []
         self._active_spool_id = None
 
@@ -130,12 +130,14 @@ class SpoolLink:
     def _handle_filament_detect_channel(self, ch: int, info: Any) -> None:
         if not isinstance(info, dict):
             return
+        event_time = info.get("CARD_EVENT_TIME") or 0
+        if event_time <= self._channel_event_times.get(ch, 0):
+            return
+        self._channel_event_times[ch] = event_time
         uid_hex = self._uid_to_hex(info.get("CARD_UID"))
-        prev = self._channel_uids.get(ch, "")
-        self._channel_uids[ch] = uid_hex
-        if uid_hex and uid_hex != prev:
-            logging.info("[spoollink] ch%d: card UID changed to %s, resolving",
-                         ch, uid_hex)
+        if uid_hex:
+            logging.info("[spoollink] ch%d: detected at %.3f (card %s), resolving",
+                         ch, event_time, uid_hex)
             self._fire(self._resolve_spool(ch, card_uid=uid_hex))
 
     # -- Active spool sync --------------------------------------------------


### PR DESCRIPTION
## Problem

A resolved spool is unassigned a few seconds after every load or tool change: `print_task_config.filament_spool_id[ch]` goes back to `0` and SpoolLink syncs `active spool = None` to Spoolman, so consumption stops being attributed. Reported in #628 and #622.

## Root cause

The firmware replaces the whole slot record on every scan report, and `06-add-spool-id-support.patch` derives `filament_spool_id` from it as `info.get('SPOOL_ID', 0)`. A scan payload never carries `SPOOL_ID` — it isn't in `FILAMENT_INFO_STRUCT`, and `filament_detect/set` rejects it as an unsupported field — so every rescan zeroes the assignment. A rescan is scheduled after every tool change, which is why this bites mid-print.

The root cause is that SpoolLink never recovers from that: it only re-resolved when `CARD_UID` changed, so a rescan of the same card — which is exactly when the spool ID is lost — did not re-trigger resolution, and the channel stayed unassigned until the card was physically removed and reinserted.

`Dragon2203` traced the firmware side on stock firmware: the toolhead filament sensor going `False -> True` during Auto Load calls `request_update_filament_info()`, which re-reads the tag and rewrites the record. The re-read succeeds (`has_params=True`) and writes back the same vendor/material/colour, dropping only the spool ID — so every observable field in `filament_detect` keeps its previous value. Before this change that re-read produced no delta in `filament_detect` at all: there was no event for Moonraker to see.

## Change

Make the detection event observable, and trigger on it.

- `patches/09-add-card-event-time.patch` adds `CARD_EVENT_TIME` to `FILAMENT_INFO_STRUCT`, stamped with `self.reactor.monotonic()` in `_filament_info_update` and in `_handle_filament_detect_set` (the clear and no-data paths bypass the former). Server-derived, not accepted from `set` params. Kept at native `float` precision — two events on one channel can land well under a second apart. Named `EVENT` because it stamps on every write, including a clear with no card present.
- `spoollink.py` tracks `CARD_EVENT_TIME` per channel as a high-water mark instead of comparing `CARD_UID`, and resolves whenever it advances and a card is present.

## Relationship to #622 and #655

Both infer that a refresh happened from its side effects; this makes the firmware emit the event instead.

#622 keys on `filament_vendor` going empty, which only covers a *tag present, no data* re-read. In the trace above the tag carries full data and vendor is rewritten identically, so the trigger cannot fire — consistent with `ofp308` and `Tom950` seeing no self-heal at all.

#655 keys on reader-state edges, a `_filament_signature` change, metadata clears and sensor timing in a 5 s window. `_filament_signature()` includes `SPOOL_ID`, but `SPOOL_ID` is never stored in `filament_detect.info`, so it is `None` on both sides while every other signature field is unchanged.

How much of #655 is still needed on top of this — `_recovery_holds`, the empty-UID fallback, `external_channels` — will be evaluated separately.

## Built-in reader vs OpenRFID on a transient read failure

Not addressed here, but worth recording since it looks like the same bug and is not.

A read that finds nothing is harmless on the built-in reader and destructive under OpenRFID.

`_fm175xx_card_info_deal_callback` hands `print_task_config` a blank `FILAMENT_INFO_STRUCT` with `is_clear=False` when a read fails, and guard A in `_rfid_filament_info_update_cb` returns early because `OFFICIAL` is `False` and the channel already has data. Nothing is lost.

The `filament_detect/set` path always passes `is_clear=True` once the slot is official, which bypasses that guard:

```python
if has_params or ptc.print_task_config['filament_official'][channel]:
    self._filament_info_update(channel, filament_info, True)
```

Both of OpenRFID's non-success exporters land there with `has_params=False` — `tag_not_present` posts only `{"channel": N}`, and `tag_parse_error` posts only `CARD_UID`/`CARD_TYPE`, which are popped before `has_params` is counted. So a momentary antenna miss or a tag that fails to parse wipes vendor, type, colour and spool id, where the built-in reader would have kept them.

Fixing that looks like passing `is_clear=has_params` instead of `True`, which gives the external path the same semantics as the native one. Clearing on actual removal is unaffected: with the built-in reader disabled, `request_clear_filament_info` already writes the blank record directly with `is_clear=True`, so presence-driven clears do not depend on the OpenRFID exporters. Separate change.
