### PR TITLE
Fix Moonraker zeroconf mDNS not resolving after boot

### DIFF
--- a/overlays/firmware-extended/12-patch-moonraker/patches/01-wait-for-network-before-zeroconf-init.patch
+++ b/overlays/firmware-extended/12-patch-moonraker/patches/01-wait-for-network-before-zeroconf-init.patch
@@ -16,3 +16,19 @@
              addresses = [x for x in self._extract_ip_addresses(network)]
              for addr_bytes in addresses:
                  try:
+@@ -219,7 +226,14 @@
+                     self.zc_service_props["ip"] = str(ip_addr)
+                 except ValueError:
+                     pass
+-            self.service_info.addresses = addresses
++            # The line below must set self.addresses (not just mutate the
++            # old, about-to-be-replaced service_info object) since the
++            # AsyncServiceInfo constructed just below reads addresses from
++            # self.addresses. Without this, the new service_info silently
++            # keeps whatever address list was set at component_init() time
++            # (empty, on first boot) instead of the current one just
++            # computed above.
++            self.addresses = addresses
+             self.service_info = AsyncServiceInfo(
+                     ZC_SERVICE_TYPE,
+                     self.zc_service_name,

--- a/overlays/firmware-extended/12-patch-moonraker/patches/01-wait-for-network-before-zeroconf-init.patch
+++ b/overlays/firmware-extended/12-patch-moonraker/patches/01-wait-for-network-before-zeroconf-init.patch
@@ -1,0 +1,18 @@
+--- a/home/lava/moonraker/moonraker/components/zeroconf.py
++++ b/home/lava/moonraker/moonraker/components/zeroconf.py
+@@ -211,7 +211,14 @@
+ 
+     async def _update_service(self, network: Dict[str, Any]) -> None:
+         if self.bound_all:
+-            await self.runner.unregister_services([self.service_info])
++            # component_init() may not have had an address to register
++            # with yet, in which case this is the first registration
++            # rather than a refresh of an existing one. Only unregister
++            # if something was actually registered, otherwise this
++            # raises and _update_service() never reaches
++            # register_services() below.
++            if self.runner.aiozc is not None:
++                await self.runner.unregister_services([self.service_info])
+             addresses = [x for x in self._extract_ip_addresses(network)]
+             for addr_bytes in addresses:
+                 try:


### PR DESCRIPTION
## Summary

Fixes Moonraker's built-in `zeroconf` component so `U1-<serial>.local` actually resolves after a normal boot. This is a stock firmware bug — reproduced and confirmed against the unmodified upstream firmware image, unrelated to anything else in this repo — and is a plausible explanation for widespread reports of printers being unreachable by hostname on the LAN.

## Root cause

`zeroconf.py` can start up before the network interface has an IP address, in which case its first registration attempt has nothing to advertise. `_update_service()` is supposed to fix this once a real IP shows up, but it unconditionally tried to unregister a responder that, in that case, was never registered yet — raising and aborting before it could re-register with the real address.

## Fix

Two small, independent changes to `moonraker/components/zeroconf.py`, applied as a patch under `overlays/firmware-extended/12-patch-moonraker/patches/`:

- Only call `unregister_services()` if something was actually registered (`self.runner.aiozc is not None`).
- Assign the freshly computed addresses to `self.addresses` (not the discarded `service_info`) so the replacement `AsyncServiceInfo` carries the real IP.

## Related

[Snapmaker/u1-moonraker#3](https://github.com/Snapmaker/u1-moonraker/pull/3) independently found and fixed the same address-assignment bug (open since 2026-04-09, not yet merged). That fix alone doesn't resolve the crash on `unregister_services()` when nothing was registered yet, which this PR also fixes.
