### PR TITLE
Add SPDX license headers to project source files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
+
 buy_me_a_coffee: paxx12

--- a/.github/dev/Dockerfile
+++ b/.github/dev/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 @paxx12, @horzadome
+
 FROM debian:trixie
 
 # The ccache is installed separately

--- a/.github/workflows/cloudflare_pages.yaml
+++ b/.github/workflows/cloudflare_pages.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 name: Deploy to Cloudflare Pages
 
 on:

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12, @horzadome
+
 on:
   push:
     branches:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12, @horzadome
+
 name: Build
 
 on:

--- a/.github/workflows/pull_request_comment.yaml
+++ b/.github/workflows/pull_request_comment.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 name: PR Comment
 
 on:

--- a/.github/workflows/update_release_pr.yaml
+++ b/.github/workflows/update_release_pr.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 name: Update Release PR Changelog
 
 on:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12, @horzadome
+
 include vars.mk
 
 all: tools

--- a/dev.sh
+++ b/dev.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 @paxx12, @liberodark
 
 set -e
 

--- a/overlays/common/01-store-version/scripts/01_store_version.sh
+++ b/overlays/common/01-store-version/scripts/01_store_version.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/common/01-store-version/scripts/02_update_boot_logo.sh
+++ b/overlays/common/01-store-version/scripts/02_update_boot_logo.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12, @liberodark
 
 set -e
 

--- a/overlays/common/03-disable-wlan-power-save/root/etc/init.d/S99wlan-powersave-disable
+++ b/overlays/common/03-disable-wlan-power-save/root/etc/init.d/S99wlan-powersave-disable
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 NAME="wlan-powersave-disable"
 DAEMON="/usr/sbin/$NAME"

--- a/overlays/common/03-disable-wlan-power-save/root/usr/sbin/wlan-powersave-disable
+++ b/overlays/common/03-disable-wlan-power-save/root/usr/sbin/wlan-powersave-disable
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 # Monitor and disable WiFi power save mode
 # Usage: wlan-powersave-disable IFACE [INTERVAL]

--- a/overlays/common/05-persist-dhcp/root/etc/init.d/S10persist-dhcp
+++ b/overlays/common/05-persist-dhcp/root/etc/init.d/S10persist-dhcp
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 export PATH

--- a/overlays/common/06-restore-eth0-mac/root/usr/local/sbin/restore-mac
+++ b/overlays/common/06-restore-eth0-mac/root/usr/local/sbin/restore-mac
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 set -eu
 

--- a/overlays/firmware-extended/01-system-utils/root/etc/profile.d/activate_path_01_usr_local.sh
+++ b/overlays/firmware-extended/01-system-utils/root/etc/profile.d/activate_path_01_usr_local.sh
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
+
 # shellcheck shell=sh disable=SC1091,SC2039,SC2166
 # Add /usr/local/bin to PATH if that directory exists
 

--- a/overlays/firmware-extended/01-system-utils/root/usr/local/bin/extended-pkg
+++ b/overlays/firmware-extended/01-system-utils/root/usr/local/bin/extended-pkg
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 #
 # Generic package manager for the optional apps installed to `/oem/apps`.

--- a/overlays/firmware-extended/01-system-utils/scripts/curl_install.sh
+++ b/overlays/firmware-extended/01-system-utils/scripts/curl_install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 set -eo pipefail
 

--- a/overlays/firmware-extended/01-system-utils/scripts/fix_timelapse_install.sh
+++ b/overlays/firmware-extended/01-system-utils/scripts/fix_timelapse_install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @horzadome, @paxx12, @liberodark
 
 GIT_URL=https://github.com/horzadome/snapmaker-u1-timelapse-recovery.git
 GIT_SHA=8e2a2e50e8642a4f368e4e4794585b2a2d2e2857

--- a/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
+++ b/overlays/firmware-extended/01-system-utils/scripts/rsync_install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 set -eo pipefail
 

--- a/overlays/firmware-extended/02-firmware-config/root/etc/init.d/S49extended-config
+++ b/overlays/firmware-extended/02-firmware-config/root/etc/init.d/S49extended-config
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 DEFAULT_DIR="/usr/local/share/firmware-config/extended"
 EXTENDED_DIR="/home/lava/printer_data/config/extended"

--- a/overlays/firmware-extended/02-firmware-config/root/etc/init.d/S99firmware-config
+++ b/overlays/firmware-extended/02-firmware-config/root/etc/init.d/S99firmware-config
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 NAME="firmware-config"
 DAEMON="/usr/local/bin/firmware-config.py"

--- a/overlays/firmware-extended/02-firmware-config/root/etc/nginx/fluidd.d/firmware-config.conf
+++ b/overlays/firmware-extended/02-firmware-config/root/etc/nginx/fluidd.d/firmware-config.conf
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 location = /firmware-config {
     return 302 /firmware-config/;
 }

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/extended-config.py
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/extended-config.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 import sys
 import os

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/firmware-config.py
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/bin/firmware-config.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 import argparse
 import glob

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/extended2.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # DO NOT REMOVE THIS FILE
 
 [web]

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/klipper/00_keep.cfg
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/klipper/00_keep.cfg
@@ -1,2 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Placeholder file to ensure the directory exists for Klipper includes.
 # Do not modify nor remove this file.

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/moonraker/00_keep.cfg
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/extended/moonraker/00_keep.cfg
@@ -1,2 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Placeholder file to ensure the directory exists for Moonraker includes.
 # Do not modify nor remove this file.

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/01_status_system.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/01_status_system.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 status:
   version:
     title: System Information

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/02_status_wlan.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/02_status_wlan.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 status:
   wlan:
     title: WLAN Network

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/03_status_eth.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/03_status_eth.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 status:
   eth:
     title: Ethernet Network

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/04_status_mmc.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/04_status_mmc.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 status:
   mmc:
     title: eMMC & Performance

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/05_settings.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/05_settings.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   web:
     label: Web

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/06_actions.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/06_actions.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 quick_actions:
   upgrades:
     label: Upgrades

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/12_settings_firmware_config.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/12_settings_firmware_config.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   web:
     items:

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/15_settings_security.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/15_settings_security.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   remote_access:
     items:

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/20_actions_troubleshooting.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/20_actions_troubleshooting.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 actions:
   troubleshooting:
     items:

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/21_actions_services.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/21_actions_services.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 actions:
   services:
     items:

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/22_actions_system.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/22_actions_system.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 actions:
   system:
     items:

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/30_upgrade.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/30_upgrade.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 upgrade_url:
   title: Firmware Upgrade (URL)
   shell: |

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/html/index.html
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/html/index.html
@@ -1,4 +1,8 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware -->
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12 -->
+
 <html>
 <head>
     <meta charset="utf-8">

--- a/overlays/firmware-extended/02-firmware-config/scripts/01-install-yaml.sh
+++ b/overlays/firmware-extended/02-firmware-config/scripts/01-install-yaml.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/02-firmware-config/test/deploy-run.sh
+++ b/overlays/firmware-extended/02-firmware-config/test/deploy-run.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <host> [optional-args]"

--- a/overlays/firmware-extended/10-patch-kernel-modules/scripts/01_compile_kernel_modules.sh
+++ b/overlays/firmware-extended/10-patch-kernel-modules/scripts/01_compile_kernel_modules.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/12-patch-moonraker/scripts/01-install-apprise.sh
+++ b/overlays/firmware-extended/12-patch-moonraker/scripts/01-install-apprise.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/12-patch-moonraker/scripts/02-install-wled.sh
+++ b/overlays/firmware-extended/12-patch-moonraker/scripts/02-install-wled.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/13-patch-rfid/pre-scripts/01_klippy_fix_lf.sh
+++ b/overlays/firmware-extended/13-patch-rfid/pre-scripts/01_klippy_fix_lf.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ $# -ne 1 ]]; then
   echo "Usage: $0 <rootfs-dir>"

--- a/overlays/firmware-extended/13-patch-rfid/root/etc/init.d/S59rfid-support
+++ b/overlays/firmware-extended/13-patch-rfid/root/etc/init.d/S59rfid-support
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 EXTENDED2_CFG="/oem/printer_data/config/extended/extended2.cfg"
 DISABLE_RFID_READER="/oem/printer_data/config/extended/klipper/disable-rfid-reader.cfg"

--- a/overlays/firmware-extended/13-patch-rfid/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
+++ b/overlays/firmware-extended/13-patch-rfid/root/home/lava/klipper/klippy/extras/filament_protocol_ndef.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 import io
 import json
 import logging

--- a/overlays/firmware-extended/13-patch-rfid/root/usr/local/share/firmware-config/functions/13_settings_rfid_reader.yaml
+++ b/overlays/firmware-extended/13-patch-rfid/root/usr/local/share/firmware-config/functions/13_settings_rfid_reader.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   snapmaker_components:
     label: Snapmaker Components

--- a/overlays/firmware-extended/13-patch-rfid/root/usr/local/share/firmware-config/tweaks/klipper/disable-rfid-reader.cfg
+++ b/overlays/firmware-extended/13-patch-rfid/root/usr/local/share/firmware-config/tweaks/klipper/disable-rfid-reader.cfg
@@ -1,2 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 [fm175xx_reader]
 enabled: False

--- a/overlays/firmware-extended/13-patch-rfid/test/app/__init__.py
+++ b/overlays/firmware-extended/13-patch-rfid/test/app/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 import os
 import pkgutil
 

--- a/overlays/firmware-extended/13-patch-rfid/test/app/cli.py
+++ b/overlays/firmware-extended/13-patch-rfid/test/app/cli.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 import os
 import sys
 import argparse

--- a/overlays/firmware-extended/13-patch-rfid/test/filament_detect.py
+++ b/overlays/firmware-extended/13-patch-rfid/test/filament_detect.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 import sys
 import json

--- a/overlays/firmware-extended/13-patch-rfid/test/filament_detect_test.py
+++ b/overlays/firmware-extended/13-patch-rfid/test/filament_detect_test.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 import sys
 import time

--- a/overlays/firmware-extended/13-patch-rfid/test/printer.cfg
+++ b/overlays/firmware-extended/13-patch-rfid/test/printer.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Minimal Klipper configuration for testing FM175xx RFID reader
 # This config provides only the bare minimum to run Klipper with the RFID reader
 

--- a/overlays/firmware-extended/13-patch-rfid/test/run.sh
+++ b/overlays/firmware-extended/13-patch-rfid/test/run.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 ROOT_DIR="$(dirname "$(realpath "$0")")/.."
 

--- a/overlays/firmware-extended/30-feature-ssh/root/usr/local/share/firmware-config/functions/14_settings_ssh.yaml
+++ b/overlays/firmware-extended/30-feature-ssh/root/usr/local/share/firmware-config/functions/14_settings_ssh.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   remote_access:
     items:

--- a/overlays/firmware-extended/31-feature-afc-lite/root/home/lava/klipper/klippy/extras/AFC.py
+++ b/overlays/firmware-extended/31-feature-afc-lite/root/home/lava/klipper/klippy/extras/AFC.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 class AFCState:
     IDLE = "idle"
     LOADING = "loading"

--- a/overlays/firmware-extended/31-feature-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
+++ b/overlays/firmware-extended/31-feature-afc-lite/root/home/lava/klipper/klippy/extras/AFC_lane.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 import logging
 
 class AFCLaneState:

--- a/overlays/firmware-extended/31-feature-afc-lite/root/home/lava/klipper/klippy/extras/AFC_unit.py
+++ b/overlays/firmware-extended/31-feature-afc-lite/root/home/lava/klipper/klippy/extras/AFC_unit.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 class AFCUnit:
     def __init__(self, config):
         # Prevent klipper error

--- a/overlays/firmware-extended/31-feature-afc-lite/root/usr/local/share/firmware-config/functions/23_settings_afc.yaml
+++ b/overlays/firmware-extended/31-feature-afc-lite/root/usr/local/share/firmware-config/functions/23_settings_afc.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   snapmaker_components:
     items:

--- a/overlays/firmware-extended/31-feature-afc-lite/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
+++ b/overlays/firmware-extended/31-feature-afc-lite/root/usr/local/share/firmware-config/tweaks/klipper/afc.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # AFC (Automated Filament Changer) Configuration and Macros
 
 [AFC]

--- a/overlays/firmware-extended/31-feature-afc-lite/test/printer.cfg
+++ b/overlays/firmware-extended/31-feature-afc-lite/test/printer.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 [mcu]
 serial: /tmp/klipper_host_mcu
 

--- a/overlays/firmware-extended/31-feature-afc-lite/test/restart.sh
+++ b/overlays/firmware-extended/31-feature-afc-lite/test/restart.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 ROOT_DIR="$(dirname "$(realpath "$0")")/.."
 

--- a/overlays/firmware-extended/31-feature-afc-lite/test/run.sh
+++ b/overlays/firmware-extended/31-feature-afc-lite/test/run.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 ROOT_DIR="$(dirname "$(realpath "$0")")/.."
 

--- a/overlays/firmware-extended/31-feature-afc-lite/test/spoolman.sh
+++ b/overlays/firmware-extended/31-feature-afc-lite/test/spoolman.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 set -euo pipefail
 

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_autotune.yaml
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_autotune.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   tweaks:
     items:

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_current.yaml
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_current.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   tweaks:
     items:

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/tmc_autotune.cfg
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/tmc_autotune.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # TMC AutoTune Configuration - Driver Parameters
 # Origin: https://github.com/Argolein/SnapmakerU1/blob/main/SnapmakerU1-CustomConfig/01_ArgoConfig.cfg
 # This configuration provides optimized TMC2240 stepper driver settings for better

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/tmc_current.cfg
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/tmc_current.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # TMC Reduced Current Configuration
 # This configuration reduces the stepper motor run current for lower heat generation
 # and quieter operation.

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/moonraker/authorization.cfg
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/moonraker/authorization.cfg
@@ -1,2 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 [authorization]
 force_logins: true

--- a/overlays/firmware-extended/33-feature-timelapse-stub/root/home/lava/moonraker/moonraker/components/timelapse.py
+++ b/overlays/firmware-extended/33-feature-timelapse-stub/root/home/lava/moonraker/moonraker/components/timelapse.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 from __future__ import annotations
 from typing import TYPE_CHECKING
 

--- a/overlays/firmware-extended/33-feature-timelapse-stub/root/usr/local/share/firmware-config/extended/moonraker/01_timelapse_stub.cfg
+++ b/overlays/firmware-extended/33-feature-timelapse-stub/root/usr/local/share/firmware-config/extended/moonraker/01_timelapse_stub.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # DO NOT REMOVE THIS FILE
 
 # Enable timelapse stub to expose in Fluidd

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/24_settings_troubleshooting_faulty_toolhead1.yaml
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/24_settings_troubleshooting_faulty_toolhead1.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   troubleshooting:
     items:

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/25_settings_troubleshooting_faulty_toolhead2.yaml
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/25_settings_troubleshooting_faulty_toolhead2.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   troubleshooting:
     items:

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/26_settings_troubleshooting_faulty_toolhead3.yaml
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/26_settings_troubleshooting_faulty_toolhead3.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   troubleshooting:
     items:

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/27_settings_troubleshooting_faulty_toolhead4.yaml
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/functions/27_settings_troubleshooting_faulty_toolhead4.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   troubleshooting:
     items:

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead1.cfg
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead1.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # faulty_toolhead_bypass: toolhead1
 # Temporary bypass for Snapmaker U1 Toolhead 1 thermistor failure.
 # Based on Snapmaker's official recovery guide for error 0003-0523-0000-0002.

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead2.cfg
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead2.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # faulty_toolhead_bypass: toolhead2
 # Temporary bypass for Snapmaker U1 Toolhead 2 thermistor failure.
 # Based on Snapmaker's official recovery guide for error 0003-0523-0000-0002.

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead3.cfg
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead3.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # faulty_toolhead_bypass: toolhead3
 # Temporary bypass for Snapmaker U1 Toolhead 3 thermistor failure.
 # Based on Snapmaker's official recovery guide for error 0003-0523-0000-0002.

--- a/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead4.cfg
+++ b/overlays/firmware-extended/34-feature-faulty-toolhead/root/usr/local/share/firmware-config/tweaks/klipper/faulty_toolhead4.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # faulty_toolhead_bypass: toolhead4
 # Temporary bypass for Snapmaker U1 Toolhead 4 thermistor failure.
 # Based on Snapmaker's official recovery guide for error 0003-0523-0000-0002.

--- a/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_print_preferences_bed_leveling_force.yaml
+++ b/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_print_preferences_bed_leveling_force.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   print_preferences:
     items:

--- a/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_print_preferences_object_processing.yaml
+++ b/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_print_preferences_object_processing.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   print_preferences:
     items:

--- a/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_print_preferences_timelapse_force.yaml
+++ b/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/functions/21_settings_print_preferences_timelapse_force.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   print_preferences:
     items:

--- a/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_adaptive_force.cfg
+++ b/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_adaptive_force.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 [gcode_macro BED_MESH_CALIBRATE]
 rename_existing: _BED_MESH_CALIBRATE_BASE
 description: Force adaptive bed mesh calibration (falls back to full mesh when exclude_object is not active)

--- a/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_force.cfg
+++ b/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/bed_leveling_force.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 [gcode_macro BED_MESH_CALIBRATE]
 rename_existing: _BED_MESH_CALIBRATE_BASE
 description: Force full bed mesh calibration

--- a/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/timelapse_force.cfg
+++ b/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/klipper/timelapse_force.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 [gcode_macro TIMELAPSE_START]
 rename_existing: _TIMELAPSE_START_BASE
 description: Force timelapse start regardless of print preferences

--- a/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/moonraker/object_processing.cfg
+++ b/overlays/firmware-extended/36-feature-print-preferences/root/usr/local/share/firmware-config/tweaks/moonraker/object_processing.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Enable Object Processing in Moonraker
 #
 # WARNING: Enabling object processing can cause problems for very large gcode files

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_cli.py
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/bin/panda_breath_cli.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12, @plastikman
+
 # WebSocket is implemented manually using stdlib `socket` and `struct` to avoid
 # any dependency on external packages (e.g. `websockets`, `aiohttp`).
 

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/functions/25_settings_snapmaker_components_panda_breath.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   snapmaker_components:
     items:

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath.cfg
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Panda Breath — Connection Settings
 # This file is used as the initial template copied into the user config directory.
 # To change settings after enabling Panda Breath, edit the user-owned copy in:

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_auto.cfg
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_auto.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Panda Breath — Managed Heater Configuration & Macros (Auto Mode)
 # This file is managed by firmware-config and must not be edited.
 # It is symlinked into your config directory and will be overwritten on firmware upgrades.

--- a/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_manual.cfg
+++ b/overlays/firmware-extended/37-feature-panda-breath/root/usr/local/share/firmware-config/tweaks/klipper/panda_breath_heater_manual.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Panda Breath — Managed Heater Configuration & Macros (Manual Mode)
 # This file is managed by firmware-config and must not be edited.
 # It is symlinked into your config directory and will be overwritten on firmware upgrades.

--- a/overlays/firmware-extended/37-feature-panda-breath/scripts/01-install-panda-breath.sh
+++ b/overlays/firmware-extended/37-feature-panda-breath/scripts/01-install-panda-breath.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 GIT_URL=https://github.com/justinh-rahb/pandabreath-klipper.git
 GIT_SHA=2fc8c03b918519060f0a2cc6b40a56fbc232e74f

--- a/overlays/firmware-extended/37-feature-panda-breath/test/run.sh
+++ b/overlays/firmware-extended/37-feature-panda-breath/test/run.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 ROOT_DIR="$(dirname "$(realpath "$0")")/.."
 

--- a/overlays/firmware-extended/38-feature-spoollink/root/etc/hooks/klipper.d/10-spoollink.sh
+++ b/overlays/firmware-extended/38-feature-spoollink/root/etc/hooks/klipper.d/10-spoollink.sh
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Reconcile the Klipper `[spoollink]` include with the Spoolman configuration.
 #
 # `[spoolman] host` in `extended2.cfg` is the single source of truth for whether

--- a/overlays/firmware-extended/38-feature-spoollink/root/etc/hooks/moonraker.d/10-spoollink.sh
+++ b/overlays/firmware-extended/38-feature-spoollink/root/etc/hooks/moonraker.d/10-spoollink.sh
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Render the Moonraker `[spoolman]` and `[spoollink]` config from the Spoolman
 # configuration.
 #

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/klipper/klippy/extras/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/klipper/klippy/extras/spoollink.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 import logging
 
 from . import filament_protocol

--- a/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
+++ b/overlays/firmware-extended/38-feature-spoollink/root/home/lava/moonraker/moonraker/components/spoollink.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # SpoolLink — bridge between Spoolman and the Snapmaker AFC/RFID stack.
 #
 # Runs inside Moonraker as a component. It registers the

--- a/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/firmware-config/functions/24_settings_snapmaker_components_spoolman.yaml
+++ b/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/firmware-config/functions/24_settings_snapmaker_components_spoolman.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   snapmaker_components:
     items:

--- a/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
+++ b/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Klipper `[spoollink]` router: exposes the `spoollink/set` endpoint and
 # forwards scanned RFID cards to the SpoolLink Moonraker component.
 # Symlinked into the extended Klipper config by klipper.d/10-spoollink.sh

--- a/overlays/firmware-extended/40-feature-upgrade-firmware/apps/firmware-imposter/Makefile
+++ b/overlays/firmware-extended/40-feature-upgrade-firmware/apps/firmware-imposter/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 CROSS_COMPILE ?=
 CC = $(CROSS_COMPILE)gcc
 STRIP = $(CROSS_COMPILE)strip

--- a/overlays/firmware-extended/40-feature-upgrade-firmware/apps/firmware-imposter/main.c
+++ b/overlays/firmware-extended/40-feature-upgrade-firmware/apps/firmware-imposter/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+// SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>

--- a/overlays/firmware-extended/40-feature-upgrade-firmware/root/etc/hooks/lmd.d/10-firmware-imposter.sh
+++ b/overlays/firmware-extended/40-feature-upgrade-firmware/root/etc/hooks/lmd.d/10-firmware-imposter.sh
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 if [ "$1" = start ]; then
     echo "Starting lmd with firmware-upgrade check disabled!"
     export LD_PRELOAD="/usr/local/lib/libfirmware-imposter.so${LD_PRELOAD:+:$LD_PRELOAD}"

--- a/overlays/firmware-extended/40-feature-upgrade-firmware/scripts/01-firmware-imposter.sh
+++ b/overlays/firmware-extended/40-feature-upgrade-firmware/scripts/01-firmware-imposter.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 CUR_DIR="$(realpath "$(dirname "$0")")"
 

--- a/overlays/firmware-extended/60-app-camera/apps/fake-service/Makefile
+++ b/overlays/firmware-extended/60-app-camera/apps/fake-service/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 CROSS_COMPILE ?=
 CC = $(CROSS_COMPILE)gcc
 

--- a/overlays/firmware-extended/60-app-camera/apps/fake-service/main.c
+++ b/overlays/firmware-extended/60-app-camera/apps/fake-service/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+// SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/overlays/firmware-extended/60-app-camera/apps/v4l2-imposter/Makefile
+++ b/overlays/firmware-extended/60-app-camera/apps/v4l2-imposter/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 CROSS_COMPILE ?=
 CC = $(CROSS_COMPILE)gcc
 STRIP = $(CROSS_COMPILE)strip

--- a/overlays/firmware-extended/60-app-camera/apps/v4l2-imposter/main.c
+++ b/overlays/firmware-extended/60-app-camera/apps/v4l2-imposter/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+// SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>

--- a/overlays/firmware-extended/60-app-camera/root/etc/hooks/lmd.d/20-camera-selection.sh
+++ b/overlays/firmware-extended/60-app-camera/root/etc/hooks/lmd.d/20-camera-selection.sh
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 if [ "$1" = start ]; then
     EXTENDED_CFG="/home/lava/printer_data/config/extended/extended2.cfg"
     CAMERA_INTERNAL=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera internal snapmaker)

--- a/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-mipi
+++ b/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-mipi
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 EXTENDED_CFG="/home/lava/printer_data/config/extended/extended2.cfg"
 CAMERA_INTERNAL=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera internal paxx12)

--- a/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-usb
+++ b/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-usb
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 EXTENDED_CFG="/home/lava/printer_data/config/extended/extended2.cfg"
 CAMERA_USB=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera usb none)

--- a/overlays/firmware-extended/60-app-camera/root/etc/udev/rules.d/99-v4l2-mpp-usb.rules
+++ b/overlays/firmware-extended/60-app-camera/root/etc/udev/rules.d/99-v4l2-mpp-usb.rules
@@ -1,2 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 KERNEL=="video19", SUBSYSTEM=="video4linux", ACTION=="add",  RUN+="/bin/sh -c 'sleep 2; /etc/init.d/S99v4l2-mpp-usb start'"
 KERNEL=="video19", SUBSYSTEM=="video4linux", ACTION=="remove", RUN+="/etc/init.d/S99v4l2-mpp-usb stop"

--- a/overlays/firmware-extended/60-app-camera/root/usr/local/share/firmware-config/extended/moonraker/02_internal_camera.cfg
+++ b/overlays/firmware-extended/60-app-camera/root/usr/local/share/firmware-config/extended/moonraker/02_internal_camera.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # DO NOT REMOVE THIS FILE
 
 # If WebRTC does not work, comment out and uncomment one of the following

--- a/overlays/firmware-extended/60-app-camera/root/usr/local/share/firmware-config/extended/moonraker/03_usb_camera.cfg
+++ b/overlays/firmware-extended/60-app-camera/root/usr/local/share/firmware-config/extended/moonraker/03_usb_camera.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # DO NOT REMOVE THIS FILE
 
 # Uncomment to enable USB camera.

--- a/overlays/firmware-extended/60-app-camera/root/usr/local/share/firmware-config/functions/15_settings_camera.yaml
+++ b/overlays/firmware-extended/60-app-camera/root/usr/local/share/firmware-config/functions/15_settings_camera.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 links:
   internal-camera:
     url: /webcam

--- a/overlays/firmware-extended/60-app-camera/scripts/01-v4l2-mpp.sh
+++ b/overlays/firmware-extended/60-app-camera/scripts/01-v4l2-mpp.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 GIT_URL=https://github.com/paxx12/v4l2-mpp.git
 GIT_SHA=a8cd3ad5acc33bab3475aea151e5a50002b742bb

--- a/overlays/firmware-extended/60-app-camera/scripts/02-extra-apps.sh
+++ b/overlays/firmware-extended/60-app-camera/scripts/02-extra-apps.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 CUR_DIR="$(realpath "$(dirname "$0")")"
 

--- a/overlays/firmware-extended/60-app-camera/test/run-imposter.sh
+++ b/overlays/firmware-extended/60-app-camera/test/run-imposter.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 ROOT_DIR="$(dirname "$(realpath "$0")")/.."
 

--- a/overlays/firmware-extended/61-app-remote-screen/pre-scripts/01-install-screen-apps.sh
+++ b/overlays/firmware-extended/61-app-remote-screen/pre-scripts/01-install-screen-apps.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/61-app-remote-screen/root/etc/init.d/S99fb-http
+++ b/overlays/firmware-extended/61-app-remote-screen/root/etc/init.d/S99fb-http
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 EXTENDED_CFG="/home/lava/printer_data/config/extended/extended2.cfg"
 REMOTE_SCREEN_ENABLED=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" web remote_screen false)

--- a/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/auth-check.conf
+++ b/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/auth-check.conf
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Internal auth check endpoint for use by 3rd party services that want to check if user is authenticated with moonraker
 location = /auth_check {
     internal;

--- a/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/remote-screen.conf
+++ b/overlays/firmware-extended/61-app-remote-screen/root/etc/nginx/fluidd.d/remote-screen.conf
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Remote screen access via fb-http
 location = /screen {
     return 301 /screen/;

--- a/overlays/firmware-extended/61-app-remote-screen/root/usr/local/share/fb-http/html/auth.js
+++ b/overlays/firmware-extended/61-app-remote-screen/root/usr/local/share/fb-http/html/auth.js
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+// SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 // Moonraker authentication: Get JWT from Fluidd/Mainsail localStorage
 function getJWT() {
     // Fluidd stores tokens as "user-token-{hash}" where hash is based on the instance

--- a/overlays/firmware-extended/61-app-remote-screen/root/usr/local/share/fb-http/html/icon.svg
+++ b/overlays/firmware-extended/61-app-remote-screen/root/usr/local/share/fb-http/html/icon.svg
@@ -1,3 +1,7 @@
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware -->
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12 -->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
   <!-- Main body -->
   <rect x="64" y="100" width="128" height="120" rx="8" fill="#f0f0f0" stroke="#333" stroke-width="4"/>

--- a/overlays/firmware-extended/61-app-remote-screen/root/usr/local/share/fb-http/html/sw.js
+++ b/overlays/firmware-extended/61-app-remote-screen/root/usr/local/share/fb-http/html/sw.js
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+// SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 // Service Worker for Snapmaker U1 Remote Screen PWA
 const CACHE_NAME = 'u1-screen-v1';
 

--- a/overlays/firmware-extended/61-app-remote-screen/root/usr/local/share/firmware-config/extended/moonraker/04_remote_screen.cfg
+++ b/overlays/firmware-extended/61-app-remote-screen/root/usr/local/share/firmware-config/extended/moonraker/04_remote_screen.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # DO NOT REMOVE THIS FILE
 
 # Uncomment to enable Remote Screen preview in Mainsail or Fluidd.

--- a/overlays/firmware-extended/61-app-remote-screen/root/usr/local/share/firmware-config/functions/12_settings_remote_screen.yaml
+++ b/overlays/firmware-extended/61-app-remote-screen/root/usr/local/share/firmware-config/functions/12_settings_remote_screen.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 links:
   remote-screen:
     url: /screen

--- a/overlays/firmware-extended/61-app-remote-screen/scripts/01-verify-screen-apps.sh
+++ b/overlays/firmware-extended/61-app-remote-screen/scripts/01-verify-screen-apps.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 ROOT_DIR="$(realpath "$(dirname "$0")/../../../..")"
 

--- a/overlays/firmware-extended/61-app-remote-screen/test/run.sh
+++ b/overlays/firmware-extended/61-app-remote-screen/test/run.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 ROOT_DIR="$(dirname "$(realpath "$0")")/.."
 

--- a/overlays/firmware-extended/62-app-fluidd/pre-scripts/01-install-fluidd.sh
+++ b/overlays/firmware-extended/62-app-fluidd/pre-scripts/01-install-fluidd.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/63-app-mainsail/root/etc/init.d/S49nginx_conf
+++ b/overlays/firmware-extended/63-app-mainsail/root/etc/init.d/S49nginx_conf
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 EXTENDED_CFG="/home/lava/printer_data/config/extended/extended2.cfg"
 SITES_ENABLED="/etc/nginx/sites-enabled"

--- a/overlays/firmware-extended/63-app-mainsail/root/etc/nginx/sites-available/mainsail
+++ b/overlays/firmware-extended/63-app-mainsail/root/etc/nginx/sites-available/mainsail
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # /etc/nginx/sites-available/mainsail
 
 server {

--- a/overlays/firmware-extended/63-app-mainsail/root/usr/local/share/firmware-config/extended/klipper/mainsail_pause_resume.cfg
+++ b/overlays/firmware-extended/63-app-mainsail/root/usr/local/share/firmware-config/extended/klipper/mainsail_pause_resume.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 [gcode_macro PAUSE]
 description: Pause the actual running print
 rename_existing: _PAUSE_BASE

--- a/overlays/firmware-extended/63-app-mainsail/root/usr/local/share/firmware-config/functions/11_settings_web_frontend.yaml
+++ b/overlays/firmware-extended/63-app-mainsail/root/usr/local/share/firmware-config/functions/11_settings_web_frontend.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 links:
   web-interface:
     url: /

--- a/overlays/firmware-extended/63-app-mainsail/scripts/01-install-mainsail.sh
+++ b/overlays/firmware-extended/63-app-mainsail/scripts/01-install-mainsail.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/64-app-openrfid/pre-scripts/01-install-openrfid.sh
+++ b/overlays/firmware-extended/64-app-openrfid/pre-scripts/01-install-openrfid.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 GIT_URL=https://github.com/suchmememanyskill/OpenRFID.git
 GIT_SHA=1a6f605d0334157b532afdd14f89fc182d9000f6

--- a/overlays/firmware-extended/64-app-openrfid/root/etc/init.d/S99openrfid
+++ b/overlays/firmware-extended/64-app-openrfid/root/etc/init.d/S99openrfid
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 PIDFILE="/var/run/openrfid.pid"
 EXTENDED2_CFG="/oem/printer_data/config/extended/extended2.cfg"

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/bin/openrfid.py
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/bin/openrfid.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 import configparser
 import logging

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/firmware-config/functions/15_settings_openrfid.yaml
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/firmware-config/functions/15_settings_openrfid.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   snapmaker_components:
     items:

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_base.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 [output_pin upper_rfid_coils_enable_pin]
 gpio_device = 1
 line = 27

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_generic.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_generic.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 [webhook_exporter success_exporter]
 method = POST
 event = tag_read

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_vendor.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_u1_vendor.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 [webhook_exporter success_exporter]
 method = POST
 event = tag_read

--- a/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_user.cfg
+++ b/overlays/firmware-extended/64-app-openrfid/root/usr/local/share/openrfid/extended/openrfid_user.cfg
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Example file on how to configure the Bambu/Creality tag processors.
 
 #[bambu_lab_tag_processor]

--- a/overlays/firmware-extended/65-app-cloud/root/etc/init.d/S99cloud
+++ b/overlays/firmware-extended/65-app-cloud/root/etc/init.d/S99cloud
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 OCTOEVERYWHERE_DAEMON="/usr/local/sbin/octoeverywhered"
 OCTOEVERYWHERE_PIDFILE="/var/run/octoeverywhere.pid"

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/sbin/octoeverywhered
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/sbin/octoeverywhered
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 DIR="/oem/apps/octoeverywhere/latest"
 PIDFILE="/var/run/octoeverywhere.pid"

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/share/extended-pkg/octoeverywhere
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/share/extended-pkg/octoeverywhere
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 PKG_LABEL="OctoEverywhere"
 PKG_VERSION=5.1.1
 PKG_URL="https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere/archive/refs/tags/${PKG_VERSION}.zip"

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/24_settings_cloud.yaml
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/24_settings_cloud.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   remote_access:
     items:

--- a/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/25_actions_cloud.yaml
+++ b/overlays/firmware-extended/65-app-cloud/root/usr/local/share/firmware-config/functions/25_actions_cloud.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 quick_actions:
   upgrades:
     items:

--- a/overlays/firmware-extended/66-app-vpn/root/etc/init.d/S99vpn
+++ b/overlays/firmware-extended/66-app-vpn/root/etc/init.d/S99vpn
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 TAILSCALE_DAEMON="/usr/local/sbin/tailscaled"
 TAILSCALE_PIDFILE="/var/run/tailscaled.pid"

--- a/overlays/firmware-extended/66-app-vpn/root/usr/local/bin/tailscale
+++ b/overlays/firmware-extended/66-app-vpn/root/usr/local/bin/tailscale
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 exec /usr/local/bin/extended-pkg tailscale exec tailscale "$@"

--- a/overlays/firmware-extended/66-app-vpn/root/usr/local/sbin/tailscaled
+++ b/overlays/firmware-extended/66-app-vpn/root/usr/local/sbin/tailscaled
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 exec /usr/local/bin/extended-pkg tailscale exec tailscaled "$@"

--- a/overlays/firmware-extended/66-app-vpn/root/usr/local/share/extended-pkg/tailscale
+++ b/overlays/firmware-extended/66-app-vpn/root/usr/local/share/extended-pkg/tailscale
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 PKG_LABEL="Tailscale"
 PKG_VERSION=1.92.5
 PKG_URL="https://pkgs.tailscale.com/stable/tailscale_${PKG_VERSION}_arm64.tgz"

--- a/overlays/firmware-extended/66-app-vpn/root/usr/local/share/firmware-config/functions/16_settings_vpn.yaml
+++ b/overlays/firmware-extended/66-app-vpn/root/usr/local/share/firmware-config/functions/16_settings_vpn.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 status:
   tailscale:
     title: Tailscale Network

--- a/overlays/firmware-extended/66-app-vpn/root/usr/local/share/firmware-config/functions/24_actions_vpn.yaml
+++ b/overlays/firmware-extended/66-app-vpn/root/usr/local/share/firmware-config/functions/24_actions_vpn.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 quick_actions:
   upgrades:
     items:

--- a/overlays/firmware-extended/67-app-monitoring/examples/example_datadog_snapmaker_u1.yaml
+++ b/overlays/firmware-extended/67-app-monitoring/examples/example_datadog_snapmaker_u1.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 ## Datadog OpenMetrics Configuration for Klipper Exporter
 ## Collects metrics from prometheus-klipper-exporter for Snapmaker U1
 ##

--- a/overlays/firmware-extended/67-app-monitoring/root/etc/init.d/S99prometheus-klipper-exporter
+++ b/overlays/firmware-extended/67-app-monitoring/root/etc/init.d/S99prometheus-klipper-exporter
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 EXTENDED_CFG="/home/lava/printer_data/config/extended/extended2.cfg"
 EXPORTER_ADDRESS=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" monitoring klipper_exporter "")

--- a/overlays/firmware-extended/67-app-monitoring/root/usr/local/share/firmware-config/functions/61_settings_monitoring.yaml
+++ b/overlays/firmware-extended/67-app-monitoring/root/usr/local/share/firmware-config/functions/61_settings_monitoring.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 settings:
   monitoring_debugging:
     items:

--- a/overlays/firmware-extended/67-app-monitoring/scripts/01-prometheus-klipper-exporter.sh
+++ b/overlays/firmware-extended/67-app-monitoring/scripts/01-prometheus-klipper-exporter.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/68-app-filament-ui/root/etc/nginx/fluidd.d/filament.conf
+++ b/overlays/firmware-extended/68-app-filament-ui/root/etc/nginx/fluidd.d/filament.conf
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 location = /filament {
     return 301 /filament/;
 }

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/index.html
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/index.html
@@ -1,4 +1,8 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware -->
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12 -->
+
 <html lang="en">
 <head>
 <meta charset="UTF-8">

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/script.js
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/script.js
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+// SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 'use strict';
 
 // Subscribe to all fields so we get state[] push updates too

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/style.css
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/filament-ui/html/style.css
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware */
+/* SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12 */
+
 :root {
     --bg: #1a1a1a;
     --card: #2d2d2d;

--- a/overlays/firmware-extended/68-app-filament-ui/root/usr/local/share/firmware-config/functions/11_links_filament_manager.yaml
+++ b/overlays/firmware-extended/68-app-filament-ui/root/usr/local/share/firmware-config/functions/11_links_filament_manager.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 links:
   filament-manager:
     url: /filament/

--- a/overlays/mods/afc/01-rules-canbus/root/etc/udev/rules.d/80-can.rules
+++ b/overlays/mods/afc/01-rules-canbus/root/etc/udev/rules.d/80-can.rules
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @jimmyjon711
+
 ACTION=="add|change", SUBSYSTEM=="net", ATTR{type}=="280", RUN+="/sbin/ip link set %k type can bitrate 1000000"
 ACTION=="add|change", SUBSYSTEM=="net", ATTR{type}=="280", RUN+="/sbin/ip link set %k up"
 ACTION=="add|change", SUBSYSTEM=="net", KERNEL=="can*", ATTR{tx_queue_len}="128"

--- a/overlays/mods/devel/01-entware/root/etc/init.d/S99entware
+++ b/overlays/mods/devel/01-entware/root/etc/init.d/S99entware
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 ENTWARE_DIR="/userdata/extended/entware"
 

--- a/overlays/mods/devel/01-entware/root/etc/profile.d/activate_path_01_entware.sh
+++ b/overlays/mods/devel/01-entware/root/etc/profile.d/activate_path_01_entware.sh
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # shellcheck shell=sh disable=SC1091,SC2039,SC2166
 # Add Entware to PATH if entware is active
 

--- a/overlays/mods/devel/01-entware/scripts/entware_installer.sh
+++ b/overlays/mods/devel/01-entware/scripts/entware_installer.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 set -eo pipefail
 

--- a/overlays/mods/paxx12/60-camera-ai-mpp/root/etc/init.d/S99detect-rknn
+++ b/overlays/mods/paxx12/60-camera-ai-mpp/root/etc/init.d/S99detect-rknn
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 EXTENDED_CFG="/home/lava/printer_data/config/extended/extended2.cfg"
 CAMERA_INTERNAL=$(/usr/local/bin/extended-config.py get "$EXTENDED_CFG" camera internal snapmaker)

--- a/overlays/mods/paxx12/60-camera-ai-mpp/root/etc/nginx/fluidd.d/detect-http.conf
+++ b/overlays/mods/paxx12/60-camera-ai-mpp/root/etc/nginx/fluidd.d/detect-http.conf
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 location = /detect-http {
     return 301 /detect-http/;
 }

--- a/overlays/mods/paxx12/60-camera-ai-mpp/root/usr/local/bin/fake-camera-agent.py
+++ b/overlays/mods/paxx12/60-camera-ai-mpp/root/usr/local/bin/fake-camera-agent.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 import os
 import sys

--- a/overlays/mods/paxx12/60-camera-ai-mpp/root/usr/local/share/firmware-config/functions/16_settings_camera_ai.yaml
+++ b/overlays/mods/paxx12/60-camera-ai-mpp/root/usr/local/share/firmware-config/functions/16_settings_camera_ai.yaml
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 links:
   detect-http:
     url: /detect-http/

--- a/overlays/mods/paxx12/60-camera-ai-mpp/scripts/01-check-apps.sh
+++ b/overlays/mods/paxx12/60-camera-ai-mpp/scripts/01-check-apps.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 EXPECTED_SHA256="d8a4c2a201b8636c399ee7dde5bd514876ae7868f5ccda6ded95e79ec70fb172"
 

--- a/overlays/mods/paxx12/60-camera-ai-mpp/scripts/02-install-rknn.sh
+++ b/overlays/mods/paxx12/60-camera-ai-mpp/scripts/02-install-rknn.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
     echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/mods/qemu/01-eth0-hotplug/root/etc/network/interfaces.d/eth0-hotplug
+++ b/overlays/mods/qemu/01-eth0-hotplug/root/etc/network/interfaces.d/eth0-hotplug
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 auto eth0

--- a/overlays/mods/qemu/02-virtio-touch/root/etc/udev/hwdb.d/61-virtio-touch.hwdb
+++ b/overlays/mods/qemu/02-virtio-touch/root/etc/udev/hwdb.d/61-virtio-touch.hwdb
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 # Map the QEMU virtio multitouch device to the U1 480x320 panel range.
 #
 # NOTE: this only rewrites the *reported* axis range (absinfo). QEMU still

--- a/overlays/mods/qemu/02-virtio-touch/scripts/01-hwdb.sh
+++ b/overlays/mods/qemu/02-virtio-touch/scripts/01-hwdb.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 set -eo pipefail
 

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 @paxx12, @liberodark
 
 set -e
 

--- a/scripts/create_firmware.sh
+++ b/scripts/create_firmware.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 if [[ $# -lt 3 ]]; then
   echo "Usage: $0 <upgrade.bin> <temp-dir> <output.bin> [overlays...]"

--- a/scripts/dev/checkout-pr.sh
+++ b/scripts/dev/checkout-pr.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 set -eo pipefail
 

--- a/scripts/dev/docker-chroot.sh
+++ b/scripts/dev/docker-chroot.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 set -e
 
 if [ $# -lt 1 ]; then

--- a/scripts/dev/find_exact_version.sh
+++ b/scripts/dev/find_exact_version.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 @paxx12, @liberodark
 
 if [[ $# -lt 3 ]]; then
   echo "Usage: $0 <repo> <local-path> [file-to-check]"

--- a/scripts/dev/qemu.sh
+++ b/scripts/dev/qemu.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ $# -ne 1 ]]; then
   echo "usage: $0 <rootfs.img>"

--- a/scripts/dev/run-klipper.sh
+++ b/scripts/dev/run-klipper.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 CONFIG_FILE="${1:-/home/lava/printer_data/config/printer.cfg}"
 

--- a/scripts/dev/save-patch.sh
+++ b/scripts/dev/save-patch.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 if [[ $# -ne 3 ]]; then
   echo "Usage: $0 <overlay> <patch-name> <file-changed-paths>"

--- a/scripts/dev/upgrade-firmware.sh
+++ b/scripts/dev/upgrade-firmware.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 @paxx12, @LixNix, @liberodark
 
 if [[ $# -ne 2 ]]; then
   echo "usage: $0 <user@ip> <profile>"

--- a/scripts/dev/upgrade-rootfs.sh
+++ b/scripts/dev/upgrade-rootfs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ $# -lt 2 ]]; then
   echo "usage: $0 <user@ip> <profile> [command]"

--- a/scripts/enable_debug_misc.sh
+++ b/scripts/enable_debug_misc.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 if [[ $# -ne 3 ]]; then
   echo "Usage: $0 <upgrade.bin> <temp-dir> <output.bin>"

--- a/scripts/extract_squashfs.sh
+++ b/scripts/extract_squashfs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 if [[ $# -ne 2 ]]; then
   echo "Usage: $0 <upgrade.bin> <output-dir>"

--- a/scripts/helpers/boot_fit.sh
+++ b/scripts/helpers/boot_fit.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 set -e
 

--- a/scripts/helpers/cache_file.sh
+++ b/scripts/helpers/cache_file.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ $# -lt 3 || $# -gt 4 ]]; then
   echo "Usage: $0 <target-file> <url> <sha256> [extract-dir]"

--- a/scripts/helpers/cache_git.sh
+++ b/scripts/helpers/cache_git.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ $# -ne 3 ]]; then
   echo "Usage: $0 <target-dir> <git-url> <git-rev>"

--- a/scripts/helpers/cache_pip.sh
+++ b/scripts/helpers/cache_pip.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 if [[ $# -lt 2 ]]; then
   echo "Usage: $0 <rootfs> [pip params]"

--- a/scripts/helpers/chroot_firmware.sh
+++ b/scripts/helpers/chroot_firmware.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 set -euo pipefail
 

--- a/scripts/helpers/pack_firmware.sh
+++ b/scripts/helpers/pack_firmware.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 if [[ $# -ne 2 ]]; then
   echo "Usage: $0 <input_dir> <output.bin>"

--- a/scripts/helpers/repack_firmware.sh
+++ b/scripts/helpers/repack_firmware.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 echo "Repacking firmware..."
 echo "$@"

--- a/scripts/helpers/unpack_firmware.sh
+++ b/scripts/helpers/unpack_firmware.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 if [[ $# -ne 2 ]]; then
   echo "Usage: $0 <upgrade.bin> <output_dir>"

--- a/scripts/next_version.sh
+++ b/scripts/next_version.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
 
 ROOT_DIR="$(realpath "$(dirname "$0")/..")"
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
+
 all: rk2918_tools upfile resource_tool
 
 # ================= Tools =================

--- a/tools/resource_tool/Makefile
+++ b/tools/resource_tool/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+
 resource_tool: resource_tool.c
 	gcc -o $@ $<
 

--- a/tools/upfile/Makefile
+++ b/tools/upfile/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
+
 upfile: upfile.c helpers.h
 	$(CC) -o upfile upfile.c -lcrypto
 

--- a/tools/upfile/helpers.h
+++ b/tools/upfile/helpers.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+// SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12, @james-coder
+
 #pragma once
 
 #ifdef __BIG_ENDIAN__

--- a/tools/upfile/upfile.c
+++ b/tools/upfile/upfile.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+// SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12, @james-coder
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
## Summary
- Adds `SPDX-License-Identifier: GPL-3.0-or-later`, `SPDX-PackageHomePage`, and `SPDX-FileCopyrightText` headers to this project's own source/script/config files
- Excludes `docs/` (Jekyll site), `tools/rk2918_tools/` (vendored Rockchip fork), `tools/resource_tool/resource_tool.c` (already has its own vendor SPDX tag), `.patch` diffs, `.md` docs, and binary/non-source files
- Copyright lines list every contributor's GitHub handle (e.g. `paxx12`, `horzadome`, `liberodark`) per file, resolved from actual commit authorship via the GitHub API rather than guessed from git display names
