### PR TITLE
chamber-heater: add opt-in Panda Breath -> DragonBreath migration action

### DIFF
--- a/overlays/firmware-extended/37-feature-chamber-heater/root/usr/local/bin/dragonbreath_migrate.py
+++ b/overlays/firmware-extended/37-feature-chamber-heater/root/usr/local/bin/dragonbreath_migrate.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @plastikman
+
+"""Convert a stock Panda Breath to DragonBreath over the network — NO USB.
+
+Stdlib only (no external deps), so it runs on the U1's stock Python.
+
+The device flip is a single HTTP POST to the stock firmware-update endpoint,
+validated on stock 1.0.3 AND 1.0.4:
+
+    POST /ota   Content-Type: application/octet-stream   header OTA-Type: ota_fw
+    body = the raw DragonBreath app image (~1.08 MB; stock size ceiling 0x480000)
+
+Stock writes it to the *inactive* OTA slot and reboots into it, leaving the stock
+app in the other slot (so the device can always boot-inactive back to stock).
+DragonBreath's first-boot NVS shim (>= v1.0.2) carries WiFi + Moonraker + HA over
+from the stock NVS, so the device rejoins with no re-provisioning.
+
+This script only performs the device flip (flash + wait-for-DragonBreath). The
+Klipper config swap + klippy restart are done by the caller (the settings-YAML cmd).
+"""
+import argparse
+import http.client
+import json
+import sys
+import time
+import urllib.request
+
+DEFAULT_IMAGE = "/usr/local/share/chamber-heater/dragonbreath.bin"
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def probe(host, timeout=4):
+    """Return the /api/v2/info dict if `host` answers as DragonBreath, else None."""
+    try:
+        with urllib.request.urlopen("http://%s/api/v2/info" % host, timeout=timeout) as r:
+            info = json.load(r)
+        if isinstance(info, dict) and info.get("project") == "dragonbreath":
+            return info
+    except Exception:
+        pass
+    return None
+
+
+def flash(host, image_path, timeout=120):
+    """POST the raw image to the stock /ota endpoint. Returns True on HTTP 200."""
+    with open(image_path, "rb") as fh:
+        body = fh.read()
+    log(">> Uploading %d bytes to http://%s/ota ..." % (len(body), host))
+    conn = http.client.HTTPConnection(host, 80, timeout=timeout)
+    try:
+        conn.request("POST", "/ota", body=body, headers={
+            "Content-Type": "application/octet-stream;charset=UTF-8",
+            "OTA-Type": "ota_fw",
+            "Content-Length": str(len(body)),
+        })
+        resp = conn.getresponse()
+        status = resp.status
+        resp.read()
+    finally:
+        conn.close()
+    log(">> /ota responded HTTP %d" % status)
+    return status == 200
+
+
+def wait_for_dragonbreath(host, timeout=90, interval=5):
+    log(">> Waiting for %s to reboot into DragonBreath ..." % host)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        info = probe(host)
+        if info:
+            log(">> DragonBreath is up (firmware %s)." % info.get("firmware"))
+            return info
+        time.sleep(interval)
+    return None
+
+
+def migrate(host, image_path):
+    # Idempotency / resume guard: already DragonBreath? skip the flash.
+    info = probe(host)
+    if info:
+        log(">> %s already reports DragonBreath (%s) — skipping flash." % (host, info.get("firmware")))
+        return 0
+    if not flash(host, image_path):
+        log("!! Flash failed: the device did not return HTTP 200. Aborting; nothing changed.")
+        return 2
+    info = wait_for_dragonbreath(host)
+    if not info:
+        log("!! Device did not come back up as DragonBreath in time.")
+        log("   The stock firmware is still in the inactive OTA slot — the device can")
+        log("   boot-inactive to revert to stock. Retry once it is reachable.")
+        return 3
+    log(">> Device flip complete.")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Panda Breath -> DragonBreath no-USB conversion")
+    ap.add_argument("--host", required=True, help="device host/IP (read from panda_breath.cfg)")
+    ap.add_argument("--image", default=DEFAULT_IMAGE, help="DragonBreath app image to flash")
+    ap.add_argument("command", nargs="?", default="migrate", choices=["migrate", "probe"],
+                    help="migrate = flip the device; probe = is it already DragonBreath?")
+    args = ap.parse_args()
+
+    if args.command == "probe":
+        info = probe(args.host)
+        print("dragonbreath" if info else "not-dragonbreath")
+        return 0 if info else 1
+    return migrate(args.host, args.image)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlays/firmware-extended/37-feature-chamber-heater/root/usr/local/share/firmware-config/functions/28_actions_chamber_heater.yaml
+++ b/overlays/firmware-extended/37-feature-chamber-heater/root/usr/local/share/firmware-config/functions/28_actions_chamber_heater.yaml
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @plastikman
+
+quick_actions:
+  chamber_heater:
+    items:
+      migrate-to-dragonbreath:
+        label: Migrate to DragonBreath
+        description: A Panda Breath chamber heater is configured. Optionally convert it to DragonBreath open firmware over Wi-Fi (no USB).
+        # Only shown while Panda Breath is the active chamber-heater integration and
+        # DragonBreath is not already enabled. Purely opt-in — nothing runs this
+        # automatically, and declining leaves Panda Breath untouched.
+        if_cmd: test -f /oem/printer_data/config/extended/klipper/panda_breath.cfg -a ! -f /oem/printer_data/config/extended/klipper/dragonbreath.cfg
+        confirm: |
+          MIGRATE YOUR CHAMBER HEATER TO DRAGONBREATH (over Wi-Fi — no USB)
+
+          This is entirely optional — Panda Breath keeps working as-is if you skip it. If you'd rather switch to DragonBreath open firmware on the same board, this flashes it over your local network — no USB cable, and neither the printer nor the Panda needs an internet connection.
+
+          What happens when you Confirm:
+          1. The bundled DragonBreath firmware is flashed to your Panda Breath over Wi-Fi. Your stock firmware is kept in the device's backup slot, so it can always revert to stock.
+          2. The device rejoins your Wi-Fi and Moonraker automatically (saved settings carry over — no re-provisioning).
+          3. Your Klipper config is switched to DragonBreath and Klipper restarts.
+
+          WARNING: A chamber heater raises sustained enclosure temperatures, accelerating wear on electronics and motors beyond their rated conditions — likely NOT warranty-covered. DragonBreath is community open firmware for a MAINS-POWERED heater with NO WARRANTY; never run it unattended. Additional motherboard cooling is required (see docs).
+
+          Confirm to migrate now. Cancel to keep using Panda Breath (you can migrate later, or flash DragonBreath yourself and use the DragonBreath option in the chamber heater setting).
+        message: "Migrating your Panda Breath to DragonBreath (do not power off the printer or the Panda)..."
+        cmd:
+          - bash
+          - -ec
+          - |
+            CFG=/oem/printer_data/config/extended/klipper
+
+            if ! test -f "$CFG/panda_breath.cfg"; then
+              echo "ERROR: No Panda Breath configuration found — nothing to migrate."
+              exit 1
+            fi
+            if test -f "$CFG/dragonbreath.cfg"; then
+              echo "ERROR: DragonBreath is already enabled."
+              exit 1
+            fi
+
+            HOST=$(/usr/local/bin/extended-config.py get "$CFG/panda_breath.cfg" panda_breath host 2>/dev/null || true)
+            if test -z "$HOST"; then
+              echo "ERROR: Could not read the Panda Breath host/IP from panda_breath.cfg."
+              exit 1
+            fi
+            echo ">> Panda Breath device: ${HOST}"
+
+            echo ""
+            echo ">> Flashing DragonBreath over Wi-Fi (this can take a minute; do not power off)..."
+            # Idempotent: if the device already reports DragonBreath (a prior run flashed
+            # but didn't finish the cfg swap) it skips the flash. Image is the bundled
+            # local copy — no internet.
+            /usr/local/bin/dragonbreath_migrate.py --host "${HOST}" migrate
+
+            echo ""
+            echo ">> Unbinding Panda Breath and switching Klipper to DragonBreath..."
+            /usr/local/bin/panda_breath_cli.py --host "${HOST}" unbind || true
+            mkdir -p "$CFG"
+            cp -n /usr/local/share/firmware-config/tweaks/klipper/dragonbreath.cfg "$CFG/dragonbreath.cfg"
+            /usr/local/bin/extended-config.py add "$CFG/dragonbreath.cfg" dragonbreath host "${HOST}"
+            chown lava:lava "$CFG/dragonbreath.cfg"
+            rm -f "$CFG/panda_breath.cfg"
+
+            echo ""
+            echo ">> Migration complete. Restarting Klipper..."
+            /etc/init.d/S60klipper restart

--- a/overlays/firmware-extended/37-feature-chamber-heater/scripts/03-bundle-dragonbreath-firmware.sh
+++ b/overlays/firmware-extended/37-feature-chamber-heater/scripts/03-bundle-dragonbreath-firmware.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @plastikman
+#
+# Bundle the pinned DragonBreath device firmware at build time.
+
+VERSION=v1.1.12
+FILENAME="dragonbreath-${VERSION}.bin"
+URL="https://github.com/plastikman/DragonBreath/releases/download/${VERSION}/dragonbreath-${VERSION}.bin"
+BIN_SHA256=8f21c98f9cdad6da4cf8e3f1aaad2453d3526ffbb30b16e79abf6f8f09e883ec
+
+if [[ -z "$CREATE_FIRMWARE" ]]; then
+  echo "Error: This script should be run within the create_firmware.sh environment."
+  exit 1
+fi
+
+set -eo pipefail
+
+echo ">> Fetching + verifying DragonBreath ${VERSION} device firmware (build host)..."
+cache_file.sh "$CACHE_DIR/$FILENAME" "$URL" "$BIN_SHA256"
+
+echo ">> Bundling DragonBreath firmware into the image..."
+install -Dm644 "$CACHE_DIR/$FILENAME" "$ROOTFS_DIR/usr/local/share/chamber-heater/dragonbreath.bin"
+
+echo ">> DragonBreath firmware bundled ($(stat -c%s "$CACHE_DIR/$FILENAME") bytes, ${VERSION})."


### PR DESCRIPTION
## What & why

Builds on #666. Adds a "Migrate to DragonBreath" quick action to the chamber-heater overlay, shown only while `panda_breath.cfg` is configured and `dragonbreath.cfg` is not. It flashes `plastikman`'s DragonBreath open firmware to the Panda Breath board over the LAN (`dragonbreath_migrate.py`, adapted from #626), then swaps the Klipper config from Panda Breath to DragonBreath and restarts klippy.

Unlike #626, this never runs automatically: no first-boot guard, no forced migration, no removal of the Panda Klipper module. It's purely a convenience for a user who already has Panda Breath configured and wants to switch to DragonBreath without doing the flash and config swap by hand. Declining leaves Panda Breath untouched.

## Notes

- Stacked on #666 — this PR's diff includes #666's commit until that one merges.
- Bundles the pinned DragonBreath device firmware into the image at build time (`03-bundle-dragonbreath-firmware.sh`, from #626) so the migrate step needs no internet access on the printer or the Panda — only the build host does.
- Single commit on top of #666.