### PR TITLE
Bump v4l2-mpp and screen-apps pins, fix requirements.txt install

### DIFF
--- a/overlays/firmware-extended/60-app-camera/scripts/01-v4l2-mpp.sh
+++ b/overlays/firmware-extended/60-app-camera/scripts/01-v4l2-mpp.sh
@@ -4,7 +4,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
 
 GIT_URL=https://github.com/paxx12/v4l2-mpp.git
-GIT_SHA=a8cd3ad5acc33bab3475aea151e5a50002b742bb
+GIT_SHA=131e5da933411ce47aef2c89be67c3c767432a02
 
 if [[ -z "$CREATE_FIRMWARE" ]]; then
   echo "Error: This script should be run within the create_firmware.sh environment."

--- a/overlays/firmware-extended/61-app-remote-screen/pre-scripts/01-install-screen-apps.sh
+++ b/overlays/firmware-extended/61-app-remote-screen/pre-scripts/01-install-screen-apps.sh
@@ -14,4 +14,4 @@ echo ">> Installing screen-apps"
 make -C "$ROOT_DIR/deps/screen-apps" install DESTDIR="$ROOTFS_DIR"
 
 echo ">> Installing Python dependencies for fb-http"
-cache_pip.sh "$ROOTFS_DIR" $(cat "$ROOT_DIR/deps/screen-apps/apps/fb-http/requirements.txt")
+cache_pip.sh "$ROOTFS_DIR" -r "$ROOT_DIR/deps/screen-apps/apps/fb-http/requirements.txt"

--- a/scripts/helpers/cache_pip.sh
+++ b/scripts/helpers/cache_pip.sh
@@ -11,6 +11,27 @@ fi
 ROOTFS_DIR="$1"
 shift
 
+PIP_ARGS=()
+STAGED_FILES=()
+cleanup() {
+  rm -f "${STAGED_FILES[@]}"
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "-r" ]]; then
+    shift
+    STAGED="/tmp/$(basename "$1").$$"
+    cp "$1" "$ROOTFS_DIR$STAGED"
+    STAGED_FILES+=("$ROOTFS_DIR$STAGED")
+    PIP_ARGS+=(-r "$STAGED")
+    shift
+  else
+    PIP_ARGS+=("$1")
+    shift
+  fi
+done
+
 chroot_cmd() {
   chroot_firmware.sh "$ROOTFS_DIR" "$@"
 }
@@ -21,4 +42,4 @@ chroot_cmd bash -c '
     pip3 download -d /cache/pip "$@" &&
     pip3 install --no-index --find-links=/cache/pip "$@"
   )
-' -- "$@"
+' -- "${PIP_ARGS[@]}"


### PR DESCRIPTION
- Bumps the `v4l2-mpp` pinned commit
- Bumps the `deps/screen-apps` submodule
- Make `cache_pip.sh` to accept a `-r <file>` argument like `pip`
  itself: it stages the file inside the chroot and passes `-r` through
  to `pip3 install`/`pip3 download`, so pip does the real
  requirements-file parsing instead of the shell