### PR TITLE
Improve extended services performance

### DIFF
--- a/overlays/firmware-extended/02-firmware-config/root/etc/init.d/S99firmware-config
+++ b/overlays/firmware-extended/02-firmware-config/root/etc/init.d/S99firmware-config
@@ -29,6 +29,10 @@ start() {
         echo "already running"
         return 1
     fi
+
+    . /usr/local/sbin/limits-helper.sh
+    limits_enter firmware-config 48M
+
     start-stop-daemon -S -b -m -p "$PIDFILE" -x /usr/bin/python3 -- \
         "$DAEMON" --bind "$BIND" --port "$PORT" \
         --html-dir "$SHAREDIR/html" \

--- a/overlays/firmware-extended/03-extended-runtime/root/usr/local/bin/memory-report
+++ b/overlays/firmware-extended/03-extended-runtime/root/usr/local/bin/memory-report
@@ -1,0 +1,72 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+#
+# Report memory usage across the whole cgroup v2 hierarchy, not just
+# the ext/* service cgroups created by limits-helper.sh - top-level
+# groups (apps, ext, rt, ...) and any nested children are all walked
+# and printed indented by depth.
+#
+
+ROOT=${CGROUP_ROOT:-/sys/fs/cgroup}
+
+human() {
+    case "$1" in
+        max|-|"") echo "${1:--}" ;;
+        *) awk "BEGIN { printf \"%.1fM\", $1 / 1048576 }" ;;
+    esac
+}
+
+# report_cgroup <dir> <depth>
+#
+# Recursive, so every local must actually be `local` - ash/dash
+# variables aren't function-scoped by default, and without this a
+# child call clobbers its parent's _depth on return, cascading the
+# indentation of every subsequent sibling.
+report_cgroup() {
+    local _dir=$1
+    local _depth=$2
+    local _name=$(basename "$_dir")
+    local _cur _peak _max _swap _procs _indent _i _sub
+
+    if [ -f "$_dir/memory.current" ]; then
+        _cur=$(cat "$_dir/memory.current" 2>/dev/null)
+        _peak=$(cat "$_dir/memory.peak" 2>/dev/null)
+        _max=$(cat "$_dir/memory.max" 2>/dev/null)
+        _swap=$(cat "$_dir/memory.swap.current" 2>/dev/null || echo -)
+        _procs=$(wc -l < "$_dir/cgroup.procs" 2>/dev/null || echo -)
+
+        _indent=""
+        _i=0
+        while [ $_i -lt "$_depth" ]; do
+            _indent="  $_indent"
+            _i=$((_i + 1))
+        done
+
+        printf "%-22s %10s %10s %10s %10s %6s\n" \
+            "${_indent}${_name}" "$(human "$_cur")" "$(human "$_peak")" "$(human "$_max")" "$(human "$_swap")" "$_procs"
+    fi
+
+    for _sub in "$_dir"/*/; do
+        [ -d "$_sub" ] || continue
+        report_cgroup "${_sub%/}" $((_depth + 1))
+    done
+}
+
+if [ ! -d "$ROOT" ]; then
+    echo "No cgroup root found at $ROOT."
+    exit 1
+fi
+
+printf "%-22s %10s %10s %10s %10s %6s\n" "CGROUP" "CURRENT" "PEAK" "MAX" "SWAP" "PROCS"
+for top in "$ROOT"/*/; do
+    [ -d "$top" ] || continue
+    report_cgroup "${top%/}" 0
+done
+
+if [ -f /proc/swaps ]; then
+    echo
+    echo "System swap:"
+    cat /proc/swaps
+fi

--- a/overlays/firmware-extended/03-extended-runtime/root/usr/local/sbin/limits-helper.sh
+++ b/overlays/firmware-extended/03-extended-runtime/root/usr/local/sbin/limits-helper.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12
+#
+# Per-service cgroup v2 memory limits for extended-firmware services.
+# Source this file in init scripts and call `limits_enter` before
+# launching daemons, so they inherit the cgroup membership (same
+# pattern as the stock S61moonraker joining the apps cgroup).
+#
+
+[ -f /usr/sbin/cgroup_helper.sh ] && . /usr/sbin/cgroup_helper.sh
+EXT_CGROUP=${CGROUP_ROOT:-/sys/fs/cgroup}/ext
+
+# apps_swap_enable
+#
+# Makes the stock `apps` cgroup swap-eligible. apps holds moonraker,
+# nginx, unisrv, gui and wpa_supplicant - NOT klipper, which the
+# stock firmware already isolates into its own `rt` cgroup (confirmed
+# via /proc/<klipper-pid>/cgroup), so real-time motion control is
+# never swap-eligible regardless of this.
+#
+# swap.max is just a permission ceiling, not a retroactive trigger:
+# apps' members already finished their startup allocations by the
+# time this runs (their own S* scripts run earlier in rcS, ours run
+# at S99), and apps sits nowhere near its memory.high/memory.max, so
+# nothing organically forces reclaim there - simply granting swap
+# access wouldn't actually move any of that already-resident cold
+# memory into zram on its own. Force it once, the first time this
+# runs (guarded on swap.max still reading "0"): memory.reclaim only
+# evicts genuinely cold/inactive pages regardless of the requested
+# size, so asking for more than what's actually reclaimable is safe -
+# it just does its best and stops, same as the kernel would do
+# organically under real pressure, just on demand instead of waiting
+# for pressure that may never meaningfully arrive.
+apps_swap_enable() {
+    [ -f /sys/fs/cgroup/apps/memory.swap.max ] || return 0
+    _apps_first_time=$(cat /sys/fs/cgroup/apps/memory.swap.max 2>/dev/null)
+
+    echo max > /sys/fs/cgroup/apps/memory.swap.max 2>/dev/null
+
+    if [ "$_apps_first_time" = "0" ]; then
+        echo 64M > /sys/fs/cgroup/apps/memory.reclaim 2>/dev/null
+    fi
+}
+
+# limits_enter <name> <memory.max>
+#
+# Create/refresh /sys/fs/cgroup/ext/<name> with the given memory.max
+# and move the calling shell (and thus every daemon it spawns) into it.
+# Degrades gracefully: if cgroup v2 is unavailable the service still
+# starts, just unlimited.
+limits_enter() {
+    _cg="$EXT_CGROUP/$1"
+
+    mkdir -p "$EXT_CGROUP" 2>/dev/null
+    echo "+memory" > "$EXT_CGROUP/cgroup.subtree_control" 2>/dev/null
+    mkdir -p "$_cg" 2>/dev/null
+
+    apps_swap_enable
+
+    if [ -f "$_cg/memory.max" ]; then
+        echo "$2" > "$_cg/memory.max" 2>/dev/null
+        echo "max" > "$_cg/memory.swap.max" 2>/dev/null
+        if echo $$ > "$_cg/cgroup.procs" 2>/dev/null; then
+            echo "limits: joined cgroup ext/$1 (memory.max=$2)"
+        else
+            echo "limits: failed to join cgroup ext/$1, running unlimited"
+        fi
+    else
+        echo "limits: memory controller unavailable for ext/$1, running unlimited"
+    fi
+
+    # Aggressive allocator tuning so freed heap actually goes back to the
+    # OS instead of sitting in glibc's arenas / CPython's pymalloc pools.
+    # PYTHONMALLOC=malloc is a no-op for the non-python services here
+    # (camera/Go binaries); harmless to set unconditionally.
+    export PYTHONMALLOC=malloc
+    export MALLOC_ARENA_MAX=1
+    export MALLOC_TRIM_THRESHOLD_=65536
+    export MALLOC_MMAP_THRESHOLD_=65536
+}

--- a/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-mipi
+++ b/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-mipi
@@ -45,6 +45,9 @@ start() {
         return
     fi
 
+    . /usr/local/sbin/limits-helper.sh
+    limits_enter camera-mipi 64M
+
     umask 0022
     mkdir -p /userdata/.tmp_timelapse
     chown -R lava:lava /userdata/.tmp_timelapse

--- a/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-usb
+++ b/overlays/firmware-extended/60-app-camera/root/etc/init.d/S99v4l2-mpp-usb
@@ -50,6 +50,9 @@ start() {
         return
     fi
 
+    . /usr/local/sbin/limits-helper.sh
+    limits_enter camera-usb 64M
+
     printf "Starting capture-usb-mpp: "
     start-stop-daemon -S -b -q -m -p /var/run/capture-usb-mpp.pid -x $CMD_FAKE_SERVICE -- $CMD_FAKE_SERVICE_ARGS $CMD_CAPTURE
     echo "OK"

--- a/overlays/firmware-extended/61-app-remote-screen/root/etc/init.d/S99fb-http
+++ b/overlays/firmware-extended/61-app-remote-screen/root/etc/init.d/S99fb-http
@@ -27,6 +27,10 @@ start() {
         echo "already running"
         return 1
     fi
+
+    . /usr/local/sbin/limits-helper.sh
+    limits_enter fb-http 48M
+
     start-stop-daemon -S -b -m -p "$PIDFILE" -x /usr/bin/python3 -- \
         "$DAEMON" --bind "$BIND" --port "$PORT" --fb "$FB_DEVICE" \
         --touch "$TOUCH_DEVICE" --html-dir "$HTML_DIR"

--- a/overlays/firmware-extended/64-app-openrfid/root/etc/init.d/S99openrfid
+++ b/overlays/firmware-extended/64-app-openrfid/root/etc/init.d/S99openrfid
@@ -34,6 +34,9 @@ start() {
         ADDITIONAL_CONFIG=""
     fi
 
+    . /usr/local/sbin/limits-helper.sh
+    limits_enter openrfid 48M
+
     printf "Starting OpenRFID: "
     start-stop-daemon -S -b -m \
         -p "$PIDFILE" \

--- a/overlays/firmware-extended/65-app-cloud/root/etc/init.d/S99cloud
+++ b/overlays/firmware-extended/65-app-cloud/root/etc/init.d/S99cloud
@@ -18,6 +18,9 @@ start_octoeverywhere() {
         return 0
     fi
 
+    . /usr/local/sbin/limits-helper.sh
+    limits_enter octoeverywhere 80M
+
     printf "Starting moonraker_octoeverywhere: "
     mkdir -p "$OCTOEVERYWHERE_STATE_DIR"
     mv "$OCTOEVERYWHERE_LOGFILE" "$OCTOEVERYWHERE_LOGFILE.old"

--- a/overlays/firmware-extended/66-app-vpn/root/etc/init.d/S99vpn
+++ b/overlays/firmware-extended/66-app-vpn/root/etc/init.d/S99vpn
@@ -17,12 +17,15 @@ start_tailscale() {
         return 0
     fi
 
+    . /usr/local/sbin/limits-helper.sh
+    limits_enter vpn 80M
+
     insmod /lib/modules/tun.ko
 
     printf "Starting tailscaled: "
     mkdir -p "$TAILSCALE_STATE_DIR"
 
-    GOMEMLIMIT=256MiB \
+    GOMEMLIMIT=64MiB \
     GOGC=70 \
     start-stop-daemon -S -b -m \
         -p "$TAILSCALE_PIDFILE" \

--- a/overlays/firmware-extended/67-app-monitoring/root/etc/init.d/S99prometheus-klipper-exporter
+++ b/overlays/firmware-extended/67-app-monitoring/root/etc/init.d/S99prometheus-klipper-exporter
@@ -21,6 +21,10 @@ start() {
         echo "already running"
         return 1
     fi
+
+    . /usr/local/sbin/limits-helper.sh
+    limits_enter monitoring 32M
+
 	start-stop-daemon -S -m -q -b -c lava -p "$PIDFILE" -x $DAEMON -- -web.listen-address "$EXPORTER_ADDRESS"
     echo "OK"
 }

--- a/overlays/mods/paxx12/60-camera-ai-mpp/root/etc/init.d/S99detect-rknn
+++ b/overlays/mods/paxx12/60-camera-ai-mpp/root/etc/init.d/S99detect-rknn
@@ -28,6 +28,9 @@ start() {
         return
     fi
 
+    . /usr/local/sbin/limits-helper.sh
+    limits_enter camera-ai 320M
+
     printf "Starting detect-bed-check: "
     start-stop-daemon -S -b -q -m -p /var/run/detect-bed-check.pid -c lava -x $CMD_PYTHON3 -- \
         /usr/local/bin/detect-rknn-yolo11.py \


### PR DESCRIPTION
Adds `limits-helper.sh` (under `03-extended-runtime`), sourced by each extended-firmware service's init script to place it into a dedicated cgroup v2 under `/sys/fs/cgroup/ext/<name>` with an aggressive `memory.max` cap. The stock OS already confines moonraker/`lmd` to the `apps` cgroup via `S05cgroup_setup`, but extended services previously ran unconstrained in the root cgroup - measured at ~200 MB PSS combined on the 1 GB device.

The init script joins the cgroup via `echo $$ > cgroup.procs` before spawning, so `start-stop-daemon`/`fake-service` children inherit membership race-free. Caps are ~2x measured idle RSS: `octoeverywhere`/`vpn` 80M (`vpn` also gets `GOMEMLIMIT=64MiB` so Go's GC engages below the cap), `camera-mipi`/`camera-usb` 64M, `camera-ai` 320M (provisional, unmeasured), `openrfid`/`fb-http`/`firmware-config` 48M, `monitoring` 32M. Also exports `PYTHONMALLOC=malloc`, `MALLOC_ARENA_MAX=1`, and malloc trim/mmap thresholds so freed heap is actually returned to the OS instead of sitting in glibc/pymalloc pools.

Also flips each `ext/*` cgroup's `memory.swap.max` from 0 to `max`, and the stock `apps` cgroup's too (scoped to moonraker/nginx/unisrv/ gui/wpa_supplicant - klipper lives in its own `rt` cgroup, confirmed via `/proc/<pid>/cgroup`, so it's never swap-eligible).

The `memory-report` walks the whole cgroup hierarchy from `/sys/fs/cgroup` down, printing `memory.current`/`memory.peak`/`memory.max`/ `memory.swap.current` per cgroup plus `/proc/swaps`, for tuning the caps after a real-world soak.