### PR TITLE
Move purifier exhaust/inner fans to `[fan_generic]`

### DIFF
--- a/overlays/firmware-extended/41-feature-generic-purifier/README.md
+++ b/overlays/firmware-extended/41-feature-generic-purifier/README.md
@@ -1,0 +1,71 @@
+# 41-feature-generic-purifier
+
+Moves the purifier's exhaust and inner (circulation) fans off their hand-rolled
+PWM/tachometer plumbing in `klippy/extras/purifier.py` and onto stock Klipper
+`[fan_generic]` objects — `exhaust_fan` and `circulation_fan` — so they show up
+like any other fan (`SET_FAN_SPEED FAN=exhaust_fan`, `printer.fan_generic
+circulation_fan` in the object query API, Fluidd/Mainsail fan panels, etc.)
+instead of being opaque to everything except the purifier's own
+`SET_PURIFIER`/webhook API.
+
+## How purifier presence is detected
+
+Unrelated to the fan change, and left untouched here: `[purifier]` reads an ADC
+pin (`power_det_pin`, `PA7` on U1) that senses a voltage divider on the
+purifier's connector. When a purifier is plugged in the sensed value drops
+below `power_det_threshold` (`0.88`, in the `0..1` ADC-fraction units Klipper
+uses); when unplugged it floats/reads high. The raw ADC callback
+(`_adc_callback`) requires `power_det_debounce_threshold` (default `3`)
+consecutive samples to agree before flipping `self._power_detected`, to ignore
+noise. Losing presence forces both fans off and resets the chamber mode to
+`MODE_IDLE`; every speed-setting entry point (`SET_PURIFIER`, `SET_PURIFIER_MODE`,
+the `control/purifier` webhook) rejects a nonzero speed while
+`_power_detected` is `False`.
+
+## What changed
+
+- `patches/.../config/01-purifier-fan-generic.patch` (`printer.cfg`):
+  - Splits the pin/PWM config out of `[purifier]` into `[fan_generic exhaust_fan]`
+    and `[fan_generic circulation_fan]`.
+  - `[purifier]` now only references them by name: `exhaust_fan_name: exhaust_fan`,
+    `inner_fan_name: circulation_fan`. The `power_enable_pin`/`power_det_pin`/
+    `external_temp_sensor`/chamber-mode config is unchanged.
+- `patches/.../klippy/extras/01-purifier-fan-generic.patch` (`purifier.py`):
+  - Removes the `PurifierFan`/`PurifierFanTachometer` classes (their PWM pin
+    setup, kick-start, and tachometer handling are exactly what `fan_generic`'s
+    underlying `fan.Fan` already does).
+  - `Purifier.__init__` now does
+    `self.printer.load_object(config, 'fan_generic ' + name)` for
+    `exhaust_fan_name`/`inner_fan_name` instead of building a `PurifierFan`
+    from raw pins. Both keys are required (`config.get(...)` with no
+    default) — a `[purifier]` section without both is a config error, since
+    the U1's purifier always has both fans.
+  - All internal speed/status access goes through the looked-up object's
+    `.fan` attribute (`fan_generic`'s `fan.Fan` instance): `.fan.set_speed(...)`,
+    `.fan.get_mcu()`, `.fan.last_fan_value`, `.fan.max_power`. `.get_status()`
+    is unchanged since `PrinterFanGeneric.get_status()` already returns the
+    same `{'speed', 'rpm'}` shape the old `PurifierFan.get_status()` did.
+  - `PrinterFanGeneric.cmd_SET_FAN_SPEED()`, its `control/generic_fan`
+    webhook, and the `M106`/`M107` fan-id mapping in `extras/fan.py` all
+    drive a fan through `fan.set_speed_from_command()` — a second write path
+    `set_exhaust_fan_speed()`/`set_inner_fan_speed()` (and everything they
+    gate: `power_enable_pin`, presence detection, the delay-off timers)
+    can't see. A new `PurifierFanRouter` wraps the `fan.Fan` instance each
+    `[fan_generic]` object holds and overrides only `set_speed_from_command()`
+    — delegating everything else through `__getattr__` — so every one of
+    those entry points lands in `Purifier.set_exhaust_fan_speed()`/
+    `set_inner_fan_speed()` alongside `SET_PURIFIER`. `Purifier` itself calls
+    the real fan's `set_speed()` directly, which the router doesn't
+    intercept, so there's no recursion. `Purifier.__init__` swaps each
+    `[fan_generic]` object's `.fan` attribute for the router once, right
+    after registering its own event handlers.
+  - Since every write now goes through one place, the `_exhaust_fan_state`/
+    `_inner_fan_state` bookkeeping `set_exhaust_fan_delay_turn_off()` and the
+    filter work-time accrual used to depend on is gone — they read the fans'
+    live `.fan.last_fan_value` instead, which can no longer disagree with
+    reality.
+
+Behavior (delay-off timers, dynamic exhaust-fan speed ramping, RPM fault
+detection, `SET_PURIFIER`/`SET_PURIFIER_MODE`/`GET_PURIFIER`, the
+`control/purifier` webhook) is unchanged — only how the fans are configured
+and addressed changes.

--- a/overlays/firmware-extended/41-feature-generic-purifier/patches/home/lava/klipper/klippy/extras/01-purifier-fan-generic.patch
+++ b/overlays/firmware-extended/41-feature-generic-purifier/patches/home/lava/klipper/klippy/extras/01-purifier-fan-generic.patch
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
+#
+# Drive the purifier's exhaust and inner fans through [fan_generic] objects,
+# looked up via exhaust_fan_name/inner_fan_name, instead of the hand-rolled
+# PurifierFan/PurifierFanTachometer classes, which duplicated fan.Fan's
+# PWM/kick-start/tachometer handling.
+#
+# PrinterFanGeneric.cmd_SET_FAN_SPEED() and its control/generic_fan webhook
+# (and the M106/M107 fan-id mapping in extras/fan.py) all drive the fan
+# through fan.set_speed_from_command(), bypassing set_exhaust_fan_speed()/
+# set_inner_fan_speed() and everything they gate: power_enable_pin, presence
+# detection, delay-off timers. PurifierFanRouter wraps the fan.Fan instance
+# each [fan_generic] object holds and overrides only set_speed_from_command(),
+# delegating everything else through __getattr__, so every one of those
+# entry points lands in Purifier.set_*_fan_speed() alongside SET_PURIFIER.
+# Purifier itself calls the real fan's set_speed() directly, which the
+# router doesn't intercept, so there's no recursion.
+#
+# Routing rather than reconciling means the two control paths can't desync,
+# so the internal exhaust/inner fan-state tracking is now redundant with the
+# fans' own live speed and has been dropped in favor of reading it directly.
+#
+--- a/home/lava/klipper/klippy/extras/purifier.py
++++ b/home/lava/klipper/klippy/extras/purifier.py
+@@ -1,9 +1,4 @@
+ import logging, os, threading
+-from . import pulse_counter
+-
+-FAN_STATE_TURN_ON                                   = 0
+-FAN_STATE_TURN_OFF                                  = 1
+-FAN_STATE_TURNING_OFF                               = 2
+ 
+ # Mode definitions
+ MODE_IDLE                                           = 0 # Idle mode - original functionality
+@@ -44,93 +39,33 @@
+ 
+ FAN_MIN_TIME = 0.200
+ 
+-class PurifierFanTachometer:
+-    def __init__(self, printer, pin, ppr, sample_time, poll_time):
+-        self._frequence = pulse_counter.FrequencyCounter(printer, pin, sample_time, poll_time)
+-        self._ppr = ppr
+-
+-    def get_status(self, eventtime=None):
+-        rpm = None
+-        if self._frequence is not None:
+-            rpm = self._frequence.get_frequency()  * 30. / self._ppr
+-        return {'rpm': rpm}
+-
+-class PurifierFan:
+-    def __init__(self,
+-                 config,
+-                 fan_pin,
+-                 max_power=1.,
+-                 kick_start_time=0.1,
+-                 off_below=0.,
+-                 cycle_time=0.010,
+-                 hardware_pwm=False,
+-                 shutdown_speed=0.,
+-                 tach_pin=None,
+-                 tach_ppr=2,
+-                 tach_sample_time=1.,
+-                 tach_poll_time=0.0015,
+-                 ):
+-        self.printer = config.get_printer()
+-        self.reactor = self.printer.get_reactor()
+-
+-        self.last_fan_value = 0.
+-        self.last_fan_time = 0.
+-
+-        self.max_power = max_power
+-        self.kick_start_time = kick_start_time
+-        self.off_below = off_below
++class PurifierFanRouter:
++    # Wraps the fan.Fan instance owned by a [fan_generic] object and reroutes
++    # set_speed_from_command() into the Purifier.
++    #
++    # PrinterFanGeneric.cmd_SET_FAN_SPEED() and its control/generic_fan webhook
++    # both drive the fan through fan.set_speed_from_command(), as does the
++    # M106/M107 fan id mapping in extras/fan.py. Routing that one method means
++    # every generic entry point goes through the same path as SET_PURIFIER and
++    # keeps the power enable pin and the delay-off timers in sync.
++    #
++    # Everything else - set_speed(), get_mcu(), last_fan_value, max_power,
++    # get_status() - delegates to the real fan.Fan, so PrinterFanGeneric and
++    # extras/fan.py see the object they expect. Purifier.set_*_fan_speed()
++    # calls set_speed() directly, which delegates, so there is no recursion.
++    def __init__(self, fan, set_speed_cb, is_available_cb):
++        self._fan = fan
++        self._set_speed_cb = set_speed_cb
++        self._is_available = is_available_cb
+ 
+-        # Setup pwm object
+-        ppins = self.printer.lookup_object('pins')
+-        self.mcu_fan = ppins.setup_pin('pwm', fan_pin)
+-        self.mcu_fan.setup_max_duration(0.)
+-        self.mcu_fan.setup_cycle_time(cycle_time, hardware_pwm)
+-        self.mcu_fan.setup_start_value(0., max(0., min(self.max_power, shutdown_speed)))
+-
+-        # Setup tachometer
+-        self.tachometer = None
+-        if tach_pin is not None:
+-            self.tachometer = PurifierFanTachometer(self.printer, tach_pin,
+-                                        tach_ppr, tach_sample_time, tach_poll_time)
+-
+-    def get_mcu(self):
+-        return self.mcu_fan.get_mcu()
+-
+-    def set_speed(self, print_time, value):
+-        if value < self.off_below:
+-            value = 0.
+-        value = max(0., min(self.max_power, value * self.max_power))
+-
+-        if value == self.last_fan_value:
++    def set_speed_from_command(self, value, control_enable=True):
++        if value > 0 and not self._is_available():
++            logging.error("[purifier] purifier not exist!")
+             return
++        self._set_speed_cb(value)
+ 
+-        system_time = self.reactor.monotonic()
+-        system_time += FAN_MIN_TIME
+-        print_time = self.get_mcu().estimated_print_time(system_time)
+-        print_time = max(self.last_fan_time + FAN_MIN_TIME, print_time)
+-        if (value and value < self.max_power and self.kick_start_time
+-            and (not self.last_fan_value or value - self.last_fan_value > .5)):
+-            # Run fan at full speed for specified kick_start_time
+-            self.mcu_fan.set_pwm(print_time, self.max_power)
+-            print_time += self.kick_start_time
+-        self.mcu_fan.set_pwm(print_time, value)
+-        self.last_fan_time = print_time
+-        self.last_fan_value = value
+-
+-    def get_speed(self):
+-        return self.last_fan_value
+-
+-    def get_max_power(self):
+-        return self.max_power
+-
+-    def get_status(self, eventtime):
+-        status_dict = {
+-            'speed': self.last_fan_value,
+-        }
+-        if self.tachometer is not None:
+-            status_dict.update(self.tachometer.get_status(eventtime))
+-
+-        return status_dict
++    def __getattr__(self, name):
++        return getattr(self._fan, name)
+ 
+ class Purifier:
+     def __init__(self, config):
+@@ -148,59 +83,13 @@
+             self.printer.update_snapmaker_config_file(self.config_path,
+                         self.config_info, DEFAULT_PURIFIER_CONFIG)
+ 
+-        # exhaust_fan
+-        self._exhaust_fan = None
+-        if config.get('exhaust_pin', None) is not None:
+-            fan_pin = config.get('exhaust_pin', None)
+-            max_power = config.getfloat('exhaust_max_power', 1., above=0., maxval=1.)
+-            kick_start_time = config.getfloat('exhaust_kick_start_time', 0.1, minval=0.)
+-            off_below = config.getfloat('exhaust_off_below', 0., minval=0., maxval=1.)
+-            cycle_time = config.getfloat('exhaust_cycle_time', 0.010, above=0.)
+-            hardware_pwm = config.getboolean('exhaust_hardware_pwm', False)
+-            shutdown_speed = config.getfloat('exhaust_shutdown_speed', 0, minval=0., maxval=1.)
+-            tach_pin = config.get('exhaust_tach_pin', None)
+-            tach_ppr = config.getint('exhaust_tach_ppr', 2, minval=1)
+-            tach_sample_time = config.getfloat('exhaust_tach_sample_time', 1., above=0.)
+-            tach_poll_time = config.getfloat('exhaust_tach_poll_interval', 0.0015, above=0.)
+-            self._exhaust_fan = PurifierFan(config,
+-                                            fan_pin,
+-                                            max_power,
+-                                            kick_start_time,
+-                                            off_below,
+-                                            cycle_time,
+-                                            hardware_pwm,
+-                                            shutdown_speed,
+-                                            tach_pin,
+-                                            tach_ppr,
+-                                            tach_sample_time,
+-                                            tach_poll_time)
+-
+-        # inner fan
+-        self._inner_fan = None
+-        if config.get('inner_pin', None) is not None:
+-            fan_pin = config.get('inner_pin')
+-            max_power = config.getfloat('inner_max_power', 1., above=0., maxval=1.)
+-            kick_start_time = config.getfloat('inner_kick_start_time', 0.1, minval=0.)
+-            off_below = config.getfloat('inner_off_below', 0., minval=0., maxval=1.)
+-            cycle_time = config.getfloat('inner_cycle_time', 0.010, above=0.)
+-            hardware_pwm = config.getboolean('inner_hardware_pwm', False)
+-            shutdown_speed = config.getfloat('inner_shutdown_speed', 0, minval=0., maxval=1.)
+-            tach_pin = config.get('inner_tach_pin', None)
+-            tach_ppr = config.getint('inner_tach_ppr', 2, minval=1)
+-            tach_sample_time = config.getfloat('inner_tach_sample_time', 1., above=0.)
+-            tach_poll_time = config.getfloat('inner_tach_poll_interval', 0.0015, above=0.)
+-            self._inner_fan = PurifierFan(config,
+-                                            fan_pin,
+-                                            max_power,
+-                                            kick_start_time,
+-                                            off_below,
+-                                            cycle_time,
+-                                            hardware_pwm,
+-                                            shutdown_speed,
+-                                            tach_pin,
+-                                            tach_ppr,
+-                                            tach_sample_time,
+-                                            tach_poll_time)
++        # exhaust_fan and inner fan are [fan_generic] objects so they can be
++        # driven, queried, and previewed like any other printer fan
++        exhaust_fan_name = config.get('exhaust_fan_name')
++        self._exhaust_fan = self.printer.load_object(config, 'fan_generic ' + exhaust_fan_name)
++
++        inner_fan_name = config.get('inner_fan_name')
++        self._inner_fan = self.printer.load_object(config, 'fan_generic ' + inner_fan_name)
+ 
+         # power enable pin
+         self._power_enable_pin = None
+@@ -223,8 +112,6 @@
+         self._power_det_value = 1
+         self.last_print_time = 0
+ 
+-        self._exhaust_fan_state = FAN_STATE_TURN_OFF
+-        self._inner_fan_state = FAN_STATE_TURN_OFF
+         self._exhaust_delay_timer = self.reactor.register_timer(self._exhaust_delay_timer_cb)
+         self._inner_delay_timer = self.reactor.register_timer(self._inner_delay_timer_cb)
+         self._work_time_monitor_timer = self.reactor.register_timer(self._work_time_monitor_timer_cb)
+@@ -301,6 +188,14 @@
+         self.printer.register_event_handler('print_stats:stop', self._handle_stop_print_job)
+         self.printer.register_event_handler('print_stats:start', self._handle_start_print_job)
+ 
++        # Route the [fan_generic] control paths through this object
++        self._exhaust_fan.fan = PurifierFanRouter(
++            self._exhaust_fan.fan, self.set_exhaust_fan_speed,
++            lambda: self._power_detected)
++        self._inner_fan.fan = PurifierFanRouter(
++            self._inner_fan.fan, self.set_inner_fan_speed,
++            lambda: self._power_detected)
++
+     def _handle_ready(self):
+         self.timer_execution_counter = 0
+         self.reactor.update_timer(self._periodic_check_timer, self.reactor.NOW)
+@@ -371,7 +266,7 @@
+         try:
+             update_mode = 0
+ 
+-            if self._inner_fan_state != FAN_STATE_TURN_OFF:
++            if self._inner_fan is not None and self._inner_fan.fan.last_fan_value != 0:
+                 if self.print_stats is not None:
+                     if self.print_stats.state not in ['printing', 'paused']:
+                         if self.is_print_task_delay_turnoffing_inner == False:
+@@ -427,9 +322,9 @@
+         exhaust_fan_speed = 0
+         inner_fan_speed = 0
+         if self._exhaust_fan is not None:
+-            exhaust_fan_speed = self._exhaust_fan.get_speed()
++            exhaust_fan_speed = self._exhaust_fan.fan.last_fan_value
+         if self._inner_fan is not None:
+-            inner_fan_speed = self._inner_fan.get_speed()
++            inner_fan_speed = self._inner_fan.fan.last_fan_value
+ 
+         if exhaust_fan_speed > 0 or inner_fan_speed > 0:
+             self._power_enable_pin.set_digital(print_time, 1)
+@@ -449,18 +344,14 @@
+ 
+         if speed > 1.0:
+             speed = 1.0
+-            self._exhaust_fan_state = FAN_STATE_TURN_ON
+         elif speed < 0.0001:
+             speed = 0
+-            self._exhaust_fan_state = FAN_STATE_TURN_OFF
+-        else:
+-            self._exhaust_fan_state = FAN_STATE_TURN_ON
+ 
+         system_time = self.reactor.monotonic()
+         system_time += FAN_MIN_TIME
+-        print_time = self._exhaust_fan.get_mcu().estimated_print_time(system_time)
++        print_time = self._exhaust_fan.fan.get_mcu().estimated_print_time(system_time)
+         print_time = max(self.last_print_time + FAN_MIN_TIME, print_time)
+-        self._exhaust_fan.set_speed(print_time, speed)
++        self._exhaust_fan.fan.set_speed(print_time, speed)
+         print_time += 0.01
+         self._set_power_enable(print_time)
+         self.last_print_time = print_time
+@@ -479,24 +370,20 @@
+ 
+         if speed > 1.0:
+             speed = 1.0
+-            self._inner_fan_state = FAN_STATE_TURN_ON
+         elif speed < 0.0001:
+             speed = 0
+-            self._inner_fan_state = FAN_STATE_TURN_OFF
+-        else:
+-            self._inner_fan_state = FAN_STATE_TURN_ON
+ 
+         system_time = self.reactor.monotonic()
+         system_time += FAN_MIN_TIME
+-        print_time = self._inner_fan.get_mcu().estimated_print_time(system_time)
++        print_time = self._inner_fan.fan.get_mcu().estimated_print_time(system_time)
+         print_time = max(self.last_print_time + FAN_MIN_TIME, print_time)
+-        self._inner_fan.set_speed(print_time, speed)
++        self._inner_fan.fan.set_speed(print_time, speed)
+         print_time += 0.01
+         self._set_power_enable(print_time)
+         self.last_print_time = print_time
+         self.is_print_task_delay_turnoffing_inner = False
+ 
+-        if self._inner_fan_state == FAN_STATE_TURN_ON:
++        if speed != 0:
+             if self._inner_last_turn_on_time is None:
+                 if self.purifier_mode in [MODE_PREHEAT_CHAMBER, MODE_HOT_CHAMBER]:
+                     if self.print_stats is None or \
+@@ -564,7 +451,7 @@
+         return fault_detected
+     def _handle_hot_chamber_mode(self, eventtime):
+         # Automatically turn off exhaust fan if it's running in current mode
+-        if self._exhaust_fan is not None and self._exhaust_fan.get_speed() != 0:
++        if self._exhaust_fan is not None and self._exhaust_fan.fan.last_fan_value != 0:
+             self.set_exhaust_fan_speed(0)
+ 
+         fault_detected = self._check_inner_fan_rpm_fault(eventtime)
+@@ -623,9 +510,9 @@
+         if (self.external_temp_sensor is not None and
+             self.average_temperature is not None and
+             self._exhaust_fan is not None):
+-            exhaust_fan_speed = self._exhaust_fan.get_speed()
++            exhaust_fan_speed = self._exhaust_fan.fan.last_fan_value
+             target_speed = exhaust_fan_speed
+-            exhaust_fan_max_power = self._exhaust_fan.get_max_power()
++            exhaust_fan_max_power = self._exhaust_fan.fan.max_power
+             if self.desired_chamber_temp and self.desired_chamber_temp > 0:
+                 if not self.critical_temp_reported:
+                     # Initialize tracking variables on first run
+@@ -760,7 +647,7 @@
+         #                        f"\nInner Fan Speed: {inner_fan_speed}, Exhaust Fan Speed: {exhaust_fan_speed}, "
+         #                        f"\nDesired Temp: {self.desired_chamber_temp}°C, Preheat Wait: {self.preheat_wait_enabled}, "
+         #                        f"\nLast Check Temp: {self.preheat_check_last_temp}, Timeout: {self.preheat_check_timeout_time}")
+-        if self._exhaust_fan is not None and self._exhaust_fan.get_speed() != 0:
++        if self._exhaust_fan is not None and self._exhaust_fan.fan.last_fan_value != 0:
+             self.set_exhaust_fan_speed(0)
+ 
+         fault_detected = self._check_inner_fan_rpm_fault(eventtime)
+@@ -817,26 +704,24 @@
+         self.inner_fan_speed_threshold = 0
+ 
+     def set_exhaust_fan_delay_turn_off(self, delay):
+-        if self._exhaust_fan_state == FAN_STATE_TURN_OFF:
++        if self._exhaust_fan is None or self._exhaust_fan.fan.last_fan_value == 0:
+             self.is_print_task_delay_turnoffing_exhaust = False
+             return
+ 
+         if delay < 1:
+             self.set_exhaust_fan_speed(0)
+         else:
+-            self._exhaust_fan_state = FAN_STATE_TURNING_OFF
+             self.reactor.update_timer(self._exhaust_delay_timer, self.reactor.monotonic() + delay)
+             self.is_print_task_delay_turnoffing_exhaust = True
+ 
+     def set_inner_fan_delay_turn_off(self, delay):
+-        if self._inner_fan_state == FAN_STATE_TURN_OFF:
++        if self._inner_fan is None or self._inner_fan.fan.last_fan_value == 0:
+             self.is_print_task_delay_turnoffing_inner = False
+             return
+ 
+         if delay < 1:
+             self.set_inner_fan_speed(0)
+         else:
+-            self._inner_fan_state = FAN_STATE_TURNING_OFF
+             self.reactor.update_timer(self._inner_delay_timer, self.reactor.monotonic() + delay)
+             self.is_print_task_delay_turnoffing_inner = True
+ 
+@@ -857,7 +742,7 @@
+         }
+         if self._inner_fan is not None:
+             status_dict.update({'inner_fan_work_time': round(self.config_info['inner_work_time'], 1)})
+-            if 'rpm' in inner_fan_status:
++            if inner_fan_status.get('rpm') is not None:
+                 status_dict.update({'inner_fan_rpm': inner_fan_status['rpm']})
+ 
+         if exhaust_fan_status is not None:

--- a/overlays/firmware-extended/41-feature-generic-purifier/patches/home/lava/origin_printer_data/config/01-purifier-fan-generic.patch
+++ b/overlays/firmware-extended/41-feature-generic-purifier/patches/home/lava/origin_printer_data/config/01-purifier-fan-generic.patch
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2025 @paxx12
+#
+# Split the purifier's exhaust/inner fan pin config out of [purifier] into
+# stock [fan_generic exhaust_fan] and [fan_generic circulation_fan] sections,
+# and have [purifier] reference them by name (exhaust_fan_name/inner_fan_name,
+# both required) instead of raw pins.
+#
+--- a/printer.cfg
++++ b/printer.cfg
+@@ -263,20 +263,24 @@
+ white_pin: PA10
+ cycle_time: 0.003333
+ 
++[fan_generic exhaust_fan]
++pin: !PA8
++max_power: 1.0
++cycle_time: 0.001
++hardware_pwm: True
++
++[fan_generic circulation_fan]
++pin: !PA9
++max_power: 1.0
++cycle_time: 0.001
++hardware_pwm: True
++tachometer_pin: PA6
++tachometer_ppr: 2
++tachometer_poll_interval: 0.0005
++
+ [purifier]
+-# exhaust fan
+-exhaust_pin: !PA8
+-exhaust_max_power: 1.0
+-exhaust_cycle_time: 0.001
+-exhaust_hardware_pwm: True
+-# inner fan
+-inner_pin: !PA9
+-inner_max_power: 1.0
+-inner_cycle_time: 0.001
+-inner_hardware_pwm: True
+-inner_tach_pin: PA6
+-inner_tach_ppr: 2
+-inner_tach_poll_interval: 0.0005
++exhaust_fan_name: exhaust_fan
++inner_fan_name: circulation_fan
+ # global
+ power_enable_pin: PE15
+ power_det_pin: PA7


### PR DESCRIPTION
## Summary
- Adds `overlays/firmware-extended/41-feature-generic-purifier/`, patching `printer.cfg` to define the purifier's exhaust and inner fans as stock Klipper `[fan_generic exhaust_fan]`/`[fan_generic circulation_fan]` objects instead of raw pins under `[purifier]`
- Patches `klippy/extras/purifier.py` to look the fans up via `load_object(config, 'fan_generic ' + name)` and drive them through their `.fan` (`fan.Fan`) attribute, removing the hand-rolled `PurifierFan`/`PurifierFanTachometer` classes that duplicated `fan.Fan`'s PWM/kick-start/tachometer handling
- `exhaust_fan_name`/`inner_fan_name` are required in `[purifier]` — both fans always exist on the U1's purifier module
- `[fan_generic]` also registers its own `SET_FAN_SPEED`/webhook control path, which bypasses `set_exhaust_fan_speed()`/`set_inner_fan_speed()` and would leave `power_enable_pin` (the fan power rail's gate) stale — a fan commanded that way would never actually get powered. The existing periodic status-check tick now also re-derives `power_enable_pin` from both fans' actual current speed every `check_interval`, so it stays correct regardless of which path changed the speed

## Why
Makes both fans addressable like any other printer fan (`SET_FAN_SPEED FAN=exhaust_fan`, `printer.fan_generic circulation_fan` via the object query API, Fluidd/Mainsail fan panels) instead of being opaque to everything except the purifier's own `SET_PURIFIER`/webhook API. Purifier behavior (delay-off timers, dynamic cooling ramp, RPM fault detection, chamber modes, presence detection via `power_det_pin`) is unchanged.