### PR TITLE
firmware-config: add Max Speed klipper tweak

### DIFF
--- a/docs/firmware_config.md
+++ b/docs/firmware_config.md
@@ -53,7 +53,7 @@ Toggle settings directly from the web interface:
 | Klipper Metrics Exporter | Enabled, Disabled | Enable Prometheus metrics |
 | VPN Provider | None, Tailscale | Enable VPN remote access (Experimental) |
 | Cloud | None, OctoEverywhere | Enable Cloud-based remote access (Experimental) |
-| Tweaks | TMC AutoTune, TMC Reduced Current, Object Processing, AFC Stub | Experimental Klipper tweaks ([tweaks](tweaks.md)) |
+| Tweaks | Max Speed, TMC AutoTune, TMC Reduced Current, Object Processing, AFC Stub | Experimental Klipper tweaks ([tweaks](tweaks.md)) |
 | Troubleshooting | Faulty Toolhead Bypass | Temporary toolhead thermistor bypass so the remaining toolheads can still be used ([faulty_toolhead](faulty_toolhead.md)) |
 | RFID Detection System | External, Snapmaker, OpenRFID, OpenRFID (force generic vendor) | Set how filament is detected ([RFID Format & Reader Design](design/rfid.md)) |
 

--- a/docs/tweaks.md
+++ b/docs/tweaks.md
@@ -161,7 +161,7 @@ Changes take effect immediately after Klipper restarts (no reboot required).
 These tweaks work by adding or removing configuration files from `/oem/printer_data/config/extended/`:
 - `klipper/tmc_autotune.cfg` - TMC AutoTune parameters
 - `klipper/tmc_current.cfg` - Reduced current settings
-- `klipper/max_speed.cfg` - Max Speed motion limits, tool change speeds and driver tuning
+- `klipper/10_max_speed.cfg` - Max Speed motion limits, tool change speeds and driver tuning
 - `moonraker/object_processing.cfg` - Moonraker object processing settings
 
 These files are automatically included by the main printer configuration if present. Manual editing of these files is not recommended as they will be overwritten by the Firmware Configuration interface.

--- a/docs/tweaks.md
+++ b/docs/tweaks.md
@@ -62,8 +62,7 @@ chopper tuning that keeps the XY drivers stable at those speeds.
 Parameters by [@JNP-1](https://github.com/JNP-1/Snapmaker-U1-Config).
 
 **What it does:**
-- Raises max XY velocity to 1000 mm/s and max acceleration to 25000 mm/s²
-- Raises square corner velocity to 8 mm/s
+- Raises max XY velocity from 500 mm/s to 1000 mm/s and max acceleration from 20000 mm/s² to 25000 mm/s²
 - Raises the tool change speed from 400 mm/s to 800 mm/s and the tool change acceleration from 5000 mm/s² to 25000 mm/s² on all four toolheads
 - Raises the dock grab speed from 10 mm/s to 40 mm/s
 - Applies TMC2240 chopper tuning (`TBL`, `TOFF`, `HEND`, `HSTRT`, `TPFD`, `VHIGHFS`, `VHIGHCHM`, `PWM_*`) tuned for high-speed movement
@@ -91,8 +90,25 @@ driver settings, and Max Speed needs the full 1.2A X/Y current. Firmware Config
 refuses to enable a conflicting combination and tells you which tweak to disable
 first.
 
-Input shaper values are printer specific and are deliberately not part of this
-tweak. Keep your own values in `extended/klipper/custom.cfg`.
+### Not ported from JNP-1's configuration
+
+[@JNP-1's repo](https://github.com/JNP-1/Snapmaker-U1-Config) is a complete
+`printer.cfg`. This tweak takes only the settings that are about speed and that
+hold on any U1. These parts are deliberately left at stock:
+
+| Not ported | Stock | JNP-1 | Why |
+|---|---|---|---|
+| `[input_shaper]` and the `[resonance_tester]` probe point | — | X 54 Hz, Y 47.5 Hz | The right values depend on your individual printer. Run `SHAPER_CALIBRATE`, then `SAVE_CONFIG`. |
+| `rotation_distance` on all four extruders | 4.95 | 5.0147 | Extruder calibration, not a speed setting. |
+| `fan_speed` on `e0`–`e3_nozzle_fan` | 1 | 0.8 | Cooling preference, unrelated to motion. |
+| Faster homing: `[homing_xyz_override] speed`, the `M204` accel cap and the homing current | 300 mm/s, `S1000`, 0.650A | 800 mm/s, `S10000`, 0.900A | See below. |
+
+Homing needs all three of those together. `speed` is an ordinary config option,
+but the accel cap and the homing current live inside that section's `gcode:`
+template, which can only be changed by restating the whole macro body. Raising
+`speed` on its own would mean homing at 800 mm/s while still capped at
+1000 mm/s² and still at 0.650A — an untested combination on sensorless homing,
+with a failure mode (crashing into an endstop) that this tweak does not cover.
 
 **Configuration:**
 This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.

--- a/docs/tweaks.md
+++ b/docs/tweaks.md
@@ -54,6 +54,49 @@ Lowers the stepper motor run current from 1.2A to 1.0A for X and Y axes.
 **Configuration:**
 This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
 
+## Max Speed
+
+Raises the XY motion limits and speeds up tool changes, together with the TMC2240
+chopper tuning that keeps the XY drivers stable at those speeds.
+
+Parameters by [@JNP-1](https://github.com/JNP-1/Snapmaker-U1-Config).
+
+**What it does:**
+- Raises max XY velocity to 1000 mm/s and max acceleration to 25000 mm/s²
+- Raises square corner velocity to 8 mm/s
+- Raises the tool change speed from 400 mm/s to 800 mm/s and the tool change acceleration from 5000 mm/s² to 25000 mm/s² on all four toolheads
+- Raises the dock grab speed from 10 mm/s to 40 mm/s
+- Applies TMC2240 chopper tuning (`TBL`, `TOFF`, `HEND`, `HSTRT`, `TPFD`, `VHIGHFS`, `VHIGHCHM`, `PWM_*`) tuned for high-speed movement
+
+**Requirements:**
+- Dock positions are calibrated correctly
+- Belt tension is correct
+- Input shaper is calibrated for your printer (run `SHAPER_CALIBRATE`)
+- Tool changes are already reliable with the stock configuration
+
+**Risks:**
+- Crashes into the tool docks if dock positions are off
+- Layer shifts and skipped steps under heavy load
+- Higher driver and motor temperatures
+- Ringing and other quality artifacts if input shaper is not calibrated
+
+**Recommendation:**
+- Calibrate the printer fully before enabling
+- Start with a small test print and watch the first tool changes
+- Disable if you see dock alignment problems or layer shifts
+
+**Note:** This tweak cannot be combined with [TMC AutoTune](#tmc-autotune) or
+[TMC Reduced Current](#tmc-reduced-current) — all three change the same TMC2240
+driver settings, and Max Speed needs the full 1.2A X/Y current. Firmware Config
+refuses to enable a conflicting combination and tells you which tweak to disable
+first.
+
+Input shaper values are printer specific and are deliberately not part of this
+tweak. Keep your own values in `extended/klipper/custom.cfg`.
+
+**Configuration:**
+This feature can **only** be configured via Firmware Configuration web interface. Manual configuration is not supported.
+
 ## Object Processing for Adaptive Mesh
 
 Enables object processing in Moonraker's file manager to support adaptive mesh features.
@@ -102,6 +145,7 @@ Changes take effect immediately after Klipper restarts (no reboot required).
 These tweaks work by adding or removing configuration files from `/oem/printer_data/config/extended/`:
 - `klipper/tmc_autotune.cfg` - TMC AutoTune parameters
 - `klipper/tmc_current.cfg` - Reduced current settings
+- `klipper/max_speed.cfg` - Max Speed motion limits, tool change speeds and driver tuning
 - `moonraker/object_processing.cfg` - Moonraker object processing settings
 
 These files are automatically included by the main printer configuration if present. Manual editing of these files is not recommended as they will be overwritten by the Firmware Configuration interface.

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_max_speed.yaml
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_max_speed.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-PackageHomePage: https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+# SPDX-FileCopyrightText: Copyright (c) 2026 @paxx12, @ni4223
+
+settings:
+  tweaks:
+    items:
+      max_speed:
+        label: Max Speed
+        description: Raises XY velocity to 1000 mm/s and acceleration to 25000 mm/s² and speeds up tool changes. Requires a fully calibrated printer.
+        help_url: http://snapmakeru1-extended-firmware.pages.dev/tweaks#max-speed
+        get_cmd:
+          - bash
+          - -c
+          - test -f /oem/printer_data/config/extended/klipper/max_speed.cfg && echo "enabled" || echo "disabled"
+        options:
+          enabled:
+            label: Enabled
+            confirm: "Enable Max Speed? This raises XY velocity to 1000 mm/s, acceleration to 25000 mm/s² and tool change speed to 800 mm/s. Only enable this if dock positions and belt tension are calibrated, input shaper is calibrated and tool changes are already reliable. Otherwise expect crashes into the docks, layer shifts and skipped steps. Cannot be combined with TMC AutoTune or TMC Reduced Current."
+            cmd:
+              - bash
+              - -xc
+              - |
+                if test -f /oem/printer_data/config/extended/klipper/tmc_autotune.cfg; then
+                  echo "ERROR: TMC AutoTune is enabled and changes the same TMC2240 driver settings."
+                  echo "Disable TMC AutoTune first, then enable Max Speed."
+                  exit 1
+                fi
+                if test -f /oem/printer_data/config/extended/klipper/tmc_current.cfg; then
+                  echo "ERROR: TMC Reduced Current is enabled and lowers the X/Y motor current."
+                  echo "Disable TMC Reduced Current first, then enable Max Speed."
+                  exit 1
+                fi
+                cp -v /usr/local/share/firmware-config/tweaks/klipper/max_speed.cfg /oem/printer_data/config/extended/klipper/max_speed.cfg &&
+                echo "Max Speed enabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+          disabled:
+            label: Disabled
+            cmd:
+              - bash
+              - -xc
+              - |
+                rm -vf /oem/printer_data/config/extended/klipper/max_speed.cfg &&
+                echo "Max Speed disabled. Restarting Klipper..." &&
+                /etc/init.d/S60klipper restart
+        default: disabled

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_max_speed.yaml
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_max_speed.yaml
@@ -12,7 +12,7 @@ settings:
         get_cmd:
           - bash
           - -c
-          - test -f /oem/printer_data/config/extended/klipper/max_speed.cfg && echo "enabled" || echo "disabled"
+          - test -f /oem/printer_data/config/extended/klipper/10_max_speed.cfg && echo "enabled" || echo "disabled"
         options:
           enabled:
             label: Enabled
@@ -31,7 +31,7 @@ settings:
                   echo "Disable TMC Reduced Current first, then enable Max Speed."
                   exit 1
                 fi
-                cp -v /usr/local/share/firmware-config/tweaks/klipper/max_speed.cfg /oem/printer_data/config/extended/klipper/max_speed.cfg &&
+                cp -v /usr/local/share/firmware-config/tweaks/klipper/10_max_speed.cfg /oem/printer_data/config/extended/klipper/10_max_speed.cfg &&
                 echo "Max Speed enabled. Restarting Klipper..." &&
                 /etc/init.d/S60klipper restart
           disabled:
@@ -40,7 +40,7 @@ settings:
               - bash
               - -xc
               - |
-                rm -vf /oem/printer_data/config/extended/klipper/max_speed.cfg &&
+                rm -vf /oem/printer_data/config/extended/klipper/10_max_speed.cfg &&
                 echo "Max Speed disabled. Restarting Klipper..." &&
                 /etc/init.d/S60klipper restart
         default: disabled

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_autotune.yaml
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_autotune.yaml
@@ -21,6 +21,11 @@ settings:
               - bash
               - -xc
               - |
+                if test -f /oem/printer_data/config/extended/klipper/max_speed.cfg; then
+                  echo "ERROR: Max Speed is enabled and changes the same TMC2240 driver settings."
+                  echo "Disable Max Speed first, then enable TMC AutoTune."
+                  exit 1
+                fi
                 cp /usr/local/share/firmware-config/tweaks/klipper/tmc_autotune.cfg /oem/printer_data/config/extended/klipper/tmc_autotune.cfg &&
                 echo "TMC AutoTune enabled. Restarting Klipper..." &&
                 /etc/init.d/S60klipper restart

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_autotune.yaml
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_autotune.yaml
@@ -21,7 +21,7 @@ settings:
               - bash
               - -xc
               - |
-                if test -f /oem/printer_data/config/extended/klipper/max_speed.cfg; then
+                if test -f /oem/printer_data/config/extended/klipper/10_max_speed.cfg; then
                   echo "ERROR: Max Speed is enabled and changes the same TMC2240 driver settings."
                   echo "Disable Max Speed first, then enable TMC AutoTune."
                   exit 1

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_current.yaml
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_current.yaml
@@ -21,7 +21,7 @@ settings:
               - bash
               - -xc
               - |
-                if test -f /oem/printer_data/config/extended/klipper/max_speed.cfg; then
+                if test -f /oem/printer_data/config/extended/klipper/10_max_speed.cfg; then
                   echo "ERROR: Max Speed is enabled and needs the full 1.2A X/Y motor current."
                   echo "Disable Max Speed first, then enable TMC Reduced Current."
                   exit 1

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_current.yaml
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/functions/21_settings_tweaks_tmc_current.yaml
@@ -21,6 +21,11 @@ settings:
               - bash
               - -xc
               - |
+                if test -f /oem/printer_data/config/extended/klipper/max_speed.cfg; then
+                  echo "ERROR: Max Speed is enabled and needs the full 1.2A X/Y motor current."
+                  echo "Disable Max Speed first, then enable TMC Reduced Current."
+                  exit 1
+                fi
                 cp -v /usr/local/share/firmware-config/tweaks/klipper/tmc_current.cfg /oem/printer_data/config/extended/klipper/tmc_current.cfg &&
                 echo "TMC Reduced Current enabled. Restarting Klipper..." &&
                 /etc/init.d/S60klipper restart

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/10_max_speed.cfg
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/10_max_speed.cfg
@@ -16,9 +16,8 @@
 # driver registers and cannot be combined with them.
 
 [printer]
-max_velocity: 1000
-max_accel: 25000
-square_corner_velocity: 8
+max_velocity: 1000  # stock: 500
+max_accel: 25000  # stock: 20000
 
 [tmc2240 stepper_x]
 run_current: 1.2  # stock current, reduced current is not safe at these speeds

--- a/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/max_speed.cfg
+++ b/overlays/firmware-extended/32-feature-klipper-tweaks/root/usr/local/share/firmware-config/tweaks/klipper/max_speed.cfg
@@ -1,0 +1,73 @@
+# Max Speed Configuration - High-Speed XY Motion and Fast Tool Changes
+# Origin: https://github.com/JNP-1/Snapmaker-U1-Config
+# Raises the XY motion limits and tool change speeds, together with the TMC2240
+# chopper tuning that keeps the XY drivers stable at those speeds.
+#
+# WARNING: Only enable this on a fully calibrated printer. Dock positions and
+# belt tension must be correct and tool changes must already be reliable with
+# the stock configuration. On an uncalibrated printer expect crashes into the
+# docks, layer shifts and skipped steps.
+#
+# Input shaper values are printer specific and are deliberately not part of this
+# tweak. Run SHAPER_CALIBRATE and keep your own values in
+# extended/klipper/custom.cfg.
+#
+# This tweak replaces TMC AutoTune and TMC Reduced Current - it changes the same
+# driver registers and cannot be combined with them.
+
+[printer]
+max_velocity: 1000
+max_accel: 25000
+square_corner_velocity: 8
+
+[tmc2240 stepper_x]
+run_current: 1.2  # stock current, reduced current is not safe at these speeds
+driver_TBL: 1
+driver_TOFF: 2
+driver_HEND: 0
+driver_HSTRT: 2
+driver_TPFD: 0
+driver_VHIGHFS: 1
+driver_VHIGHCHM: 1
+driver_PWM_AUTOGRAD: False
+driver_PWM_GRAD: 8
+driver_PWM_OFS: 29
+driver_PWM_REG: 4
+driver_PWM_LIM: 8
+
+[tmc2240 stepper_y]
+run_current: 1.2  # stock current, reduced current is not safe at these speeds
+driver_TBL: 1
+driver_TOFF: 2
+driver_HEND: 0
+driver_HSTRT: 2
+driver_TPFD: 0
+driver_VHIGHFS: 1
+driver_VHIGHCHM: 1
+driver_PWM_AUTOGRAD: False
+driver_PWM_GRAD: 8
+driver_PWM_OFS: 29
+driver_PWM_REG: 4
+driver_PWM_LIM: 8
+
+# Faster tool changes for all four toolheads
+
+[extruder]
+fast_move_speed: 800  # stock: 400
+grab_speed: 40  # stock: 10
+switch_accel: 25000  # stock: 5000
+
+[extruder1]
+fast_move_speed: 800  # stock: 400
+grab_speed: 40  # stock: 10
+switch_accel: 25000  # stock: 5000
+
+[extruder2]
+fast_move_speed: 800  # stock: 400
+grab_speed: 40  # stock: 10
+switch_accel: 25000  # stock: 5000
+
+[extruder3]
+fast_move_speed: 800  # stock: 400
+grab_speed: 40  # stock: 10
+switch_accel: 25000  # stock: 5000


### PR DESCRIPTION
Adds a `Max Speed` tweak to the firmware-config web interface under **Settings → Tweaks**, following the same pattern as `TMC AutoTune` and `TMC Reduced Current`.

<img width="1020" height="133" alt="Screenshot 2026-08-30 at 9 22 54 PM" src="https://github.com/user-attachments/assets/d37fce93-8a09-4da4-8668-f9944b7fff3a" />

<img width="974" height="392" alt="image" src="https://github.com/user-attachments/assets/97bcd0eb-2d0e-4b84-8abe-71e8f01f7dab" />


Requested in JNP-1/Snapmaker-U1-Config#4.

## What it does

Installs `extended/klipper/10_max_speed.cfg` when enabled, removes it when disabled, and restarts Klipper:

- `[printer]` — max XY velocity 500 → 1000 mm/s, max acceleration 20000 → 25000 mm/s²
- `[tmc2240 stepper_x/y]` — chopper tuning for high-speed movement (`TBL`, `TOFF`, `HEND`, `HSTRT`, `TPFD`, `VHIGHFS`, `VHIGHCHM`, `PWM_*`), with the stock 1.2A run current re-asserted
- `[extruder]`…`[extruder3]` — tool change speed 400 → 800 mm/s, tool change acceleration 5000 → 25000 mm/s², dock grab speed 10 → 40 mm/s

Parameters by @JNP-1 (https://github.com/JNP-1/Snapmaker-U1-Config), tested there on v1.1.1-paxx12-13.

## Not ported from JNP-1's configuration

Their repo is a complete `printer.cfg`; this tweak takes only the settings that are about speed and that hold on any U1. Deliberately left at stock: `[input_shaper]` and the resonance probe point (per-printer — run `SHAPER_CALIBRATE`, then `SAVE_CONFIG`), extruder `rotation_distance` (extruder calibration, not speed), nozzle `fan_speed` (cooling preference), and faster homing.

Homing is the one judgement call. `[homing_xyz_override] speed` is an ordinary option and could be raised from a drop-in config, but the `M204` accel cap and the 0.900A homing current that go with it live inside that section's `gcode:` template, which can only be changed by restating the whole macro body. Raising `speed` alone would mean homing at 800 mm/s while still capped at 1000 mm/s² and still at 0.650A — an untested combination on sensorless homing, with a failure mode (crashing into an endstop) this tweak does not cover.

The docs record all of this in the `Max Speed` section.

## Mutual exclusion with the TMC tweaks

`Max Speed`, `TMC AutoTune` and `TMC Reduced Current` all write the same TMC2240 driver registers, and reduced current is not safe at 1000 mm/s. Relying on the `extended/klipper/*.cfg` include order would have left AutoTune's CoolStep parameters (`SEMIN`/`SEUP`/`SEMAX`/…) active in an untested mix, so instead enabling one while another is active fails with an explicit message naming the tweak to disable first. That is a 5-line guard added to each of the two existing tweaks.

## The `10_` prefix

Klipper sorts the `extended/klipper/*.cfg` glob, so a plain `max_speed.cfg` is read *after* the user's `custom.cfg` and silently overrides any motion limits set there. The `10_` prefix moves it ahead of `custom.cfg` so the user's own values win. `tmc_autotune.cfg` and `tmc_current.cfg` still sort after it — that is what the guards above are for.

## Testing

**On hardware:** flashed the CI build on my U1 and ran a print exercising repeated tool changes at these speeds. All fine — video in the comment below.

Verified offline against the real stock config extracted from `U1_1.6.0.267_20260815150420_upgrade.bin` (`home/lava/origin_printer_data/config/printer.cfg`), rather than against JNP-1's annotations:

- Every option the tweak overrides already exists in the stock config, so Klipper cannot abort with an unused-option error. `fast_move_speed`, `grab_speed` and `switch_accel` are present on all four extruders at exactly 400 / 10 / 5000, and `run_current` is 1.2 — the values quoted in the comments are correct.
- All 12 `driver_*` overrides map to real register fields in that image's `klippy/extras/tmc2240.py`, including `vhighfs` and `vhighchm`, which no existing tweak uses.
- Merging the tweak onto the stock config yields the documented values; removing the file leaves no residue.
- `custom.cfg` keeps precedence over `10_max_speed.cfg`, and the tweak shares no option with the faulty-toolhead bypass files.
- All four conflicting combinations are refused with exit code 1 and a message naming the blocking tweak by its interface label — re-checked after the rename, since that is the part of it a diff cannot show.
- All 40 firmware-config function YAML files still load and deep-merge; the new item shows up in the `Tweaks` group. `bash -n` clean on every tweak command.

`square_corner_velocity` was dropped from the tweak: stock 1.6.0.267 is already 8, so setting it did nothing.

@JNP-1 — the parameters here are yours and your repo has no LICENSE file, so please confirm you are fine with them being contributed under this project's GPL-3.0.
