### PR TITLE
fix(spoollink): add missing fallback for E-prefixed lanes in SET_SPOO…

### DIFF
--- a/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
+++ b/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
@@ -43,4 +43,3 @@ gcode:
         { action_call_remote_method("spoollink_resolve_spool",
             channel=channel, spool_id=spool_id, card_uid=card_uid) }
     {% endif %}
-    

--- a/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
+++ b/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
@@ -17,14 +17,17 @@
 [gcode_macro SET_SPOOL_ID]
 description: Assign a Spoolman spool to an extruder channel
 gcode:
-    {% set lane     = params.LANE|default('') %}
+    {% set lane = params.LANE|default('')|string %}
     {% if params.CHANNEL is defined %}
         {% set channel = params.CHANNEL|int %}
     {% elif 'AFC_lane ' + lane in printer %}
         {% set channel = printer['AFC_lane ' + lane].lane %}
+    {% elif lane.startswith('E') and lane|length > 1 %}
+        {% set channel = lane[1:]|int %}
     {% else %}
         { action_raise_error("SET_SPOOL_ID: unknown LANE '" ~ lane ~ "', pass CHANNEL=<index> instead") }
     {% endif %}
+    
     {% set spool_id = params.SPOOL_ID|default(0)|int %}
     {% if spool_id == 0 %}
         SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER={channel} FILAMENT_SPOOL_ID=0 FORCE=1

--- a/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
+++ b/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
@@ -43,3 +43,4 @@ gcode:
         { action_call_remote_method("spoollink_resolve_spool",
             channel=channel, spool_id=spool_id, card_uid=card_uid) }
     {% endif %}
+    


### PR DESCRIPTION
### **Description**
When assigning a spool via the Web UI without AFC-Lite installed, the macro fails with `unknown LANE 'E0'`. The comment above the macro states that it should fall back to the lane name itself (`E0` -> `0`), but the logic to parse this was missing.

### **Changes**
* Added an `elif` condition to check if the lane starts with `E` and has a valid length.
* Extracts the integer following the `E` prefix to map it to the correct channel.
* Preserves priority of `CHANNEL` parameter and `AFC_lane` definitions.

### **Testing**
Tsted gcode macro locally
Spool assignment via Web UI now successfully maps `LANE=E0` to `channel=0` and reports to Spoolman without raising an exception.