### PR TITLE
Give `develop` channel its own firmware-imposter rewrite URL

### DIFF
--- a/overlays/firmware-extended/40-feature-upgrade-firmware/root/etc/hooks/lmd.d/10-firmware-imposter.sh
+++ b/overlays/firmware-extended/40-feature-upgrade-firmware/root/etc/hooks/lmd.d/10-firmware-imposter.sh
@@ -9,12 +9,19 @@ if [ "$1" = start ]; then
     export FW_UPDATE_URL="/api/device/firmware/latest"
 
     case "$FIRMWARE_IMPOSTER" in
-        stable|testing|develop)
+        stable|testing)
             echo "Starting lmd with firmware-upgrade imposter (channel=$FIRMWARE_IMPOSTER)!"
             VERSION=$(cat /etc/VERSION 2>/dev/null)
             BUILD_VERSION=$(cat /etc/BUILD_VERSION 2>/dev/null)
             BUILD_PROFILE=$(cat /etc/BUILD_PROFILE 2>/dev/null)
             export FW_UPDATE_REWRITE_URL="https://snapmakeru1-extended-firmware.pages.dev/api/device/firmware/latest?channel=$FIRMWARE_IMPOSTER&version=$VERSION&build_version=$BUILD_VERSION&build_profile=$BUILD_PROFILE"
+            ;;
+        develop)
+            echo "Starting lmd with firmware-upgrade imposter in develop mode (channel=$FIRMWARE_IMPOSTER)!"
+            VERSION=$(cat /etc/VERSION 2>/dev/null)
+            BUILD_VERSION=$(cat /etc/BUILD_VERSION 2>/dev/null)
+            BUILD_PROFILE=$(cat /etc/BUILD_PROFILE 2>/dev/null)
+            export FW_UPDATE_REWRITE_URL="https://develop.snapmakeru1-extended-firmware.pages.dev/api/device/firmware/latest?channel=$FIRMWARE_IMPOSTER&version=$VERSION&build_version=$BUILD_VERSION&build_profile=$BUILD_PROFILE"
             ;;
         *)
             echo "Starting lmd with firmware-upgrade check disabled!"


### PR DESCRIPTION
## Summary

- Splits the `develop` case out of the `stable|testing|develop` branch in `10-firmware-imposter.sh`
- Points `FW_UPDATE_REWRITE_URL` for `develop` at `develop.snapmakeru1-extended-firmware.pages.dev` instead of the production Pages URL, so develop-channel firmware checks stay isolated from stable/testing