### PR TITLE
Fix duplicate spool assignments due to NFC Crosstalk

### DIFF
--- a/docs/design/filament_detect.md
+++ b/docs/design/filament_detect.md
@@ -105,6 +105,9 @@ The endpoint has three modes determined by the filament fields present in `info`
 
 `CARD_UID` and `CARD_TYPE` are both popped before `has_params` is computed, so they never contribute to `OFFICIAL`. `CARD_TYPE` is populated automatically on hardware reads (`NTAG` via `filament_protocol_ndef`, `M1` via `filament_protocol`).
 
+A non-empty `CARD_UID` may only be assigned to one channel at a time. Repeating the same UID, but assigning it to another channel is rejected with an API
+error. The first successful assignment remains authoritative until that channel is cleared.
+
 ## openrfid Integration
 
 `openrfid_u1_base.cfg` registers two webhook exporters that drive `filament_detect/set` automatically:

--- a/overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch
+++ b/overlays/firmware-extended/13-patch-rfid/patches/05-add-filament-detect-set-endpoint.patch
@@ -27,7 +27,17 @@
 +            params = web_request.get_dict('info', {})
 +            filament_info = dict(filament_protocol.FILAMENT_INFO_STRUCT)
 +            if 'CARD_UID' in params:
-+                filament_info['CARD_UID'] = [int(b) for b in params.pop('CARD_UID')]
++                card_uid = [int(b) & 0xFF for b in params.pop('CARD_UID')]
++                if card_uid:
++                    for other_channel, other_info in enumerate(self._filament_info):
++                        if other_channel == channel:
++                            continue
++                        other_uid = other_info.get('CARD_UID', 0)
++                        if isinstance(other_uid, (list, tuple)) and list(other_uid) == card_uid:
++                            raise web_request.error(
++                                "CARD_UID %s is already assigned to channel %d"
++                                % (card_uid, other_channel))
++                filament_info['CARD_UID'] = card_uid
 +            if 'CARD_TYPE' in params:
 +                filament_info['CARD_TYPE'] = str(params.pop('CARD_TYPE'))
 +

--- a/overlays/firmware-extended/13-patch-rfid/test/filament_detect_test.py
+++ b/overlays/firmware-extended/13-patch-rfid/test/filament_detect_test.py
@@ -6,6 +6,7 @@
 import sys
 import time
 import argparse
+import urllib.error
 
 import filament_detect as fd
 
@@ -195,6 +196,28 @@ def main():
     rfid, ptc = get_state(host)
     expect("CARD_EVENT_TIME is still stamped on a clear (it marks detection activity, not tag content)")
     check("rfid.CARD_EVENT_TIME > 0 after clear", rfid.get("CARD_EVENT_TIME", 0) > 0, True)
+
+    section("Step 8: reject the same CARD_UID on another channel")
+    reset(host)
+    fd.cmd_clear_rfid(host, 1)
+    op(f"set-rfid channel=0 with CARD_UID={RFID_CARD_UID}")
+    fd.cmd_set_rfid(host, 0, RFID_VENDOR, RFID_TYPE, RFID_SUBTYPE, RFID_COLOR,
+                    card_uid=RFID_CARD_UID)
+    op(f"set-rfid channel=1 with the same CARD_UID={RFID_CARD_UID}")
+    try:
+        result = fd.post(host, "filament_detect/set", {
+            "channel": 1,
+            "info": {
+                "VENDOR": RFID_VENDOR,
+                "MAIN_TYPE": RFID_TYPE,
+                "SUB_TYPE": RFID_SUBTYPE,
+                "RGB_1": int(RFID_COLOR, 16),
+                "CARD_UID": RFID_CARD_UID,
+            },
+        })
+        check("duplicate CARD_UID rejected", result.get("state") == "error", True)
+    except urllib.error.HTTPError:
+        check("duplicate CARD_UID rejected", True, True)
 
     print(f"\n{'OK' if _failures == 0 else 'FAILED'}  {_passes} passed, {_failures} failed")
     sys.exit(0 if _failures == 0 else 1)

--- a/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
+++ b/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
@@ -40,3 +40,4 @@ gcode:
         { action_call_remote_method("spoollink_resolve_spool",
             channel=channel, spool_id=spool_id, card_uid=card_uid) }
     {% endif %}
+    


### PR DESCRIPTION
### Problem
Due to physical proximity, the upper NFC reader sometimes captures the tag of a spool placed in the lower spool holder with a slight delay, assigning the same spool to both channels.

### Solution
Added a deduplication check to prevent assigning an NFC tag UID if it is already active on another channel.

### Testing
Proper testing still has to be done, to see if it works on hardware