### PR TITLE
Add `extended-afc` build variant to develop CI

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -106,6 +106,14 @@ jobs:
         name: extended-build
         path: U1_extended_*_upgrade.bin
 
+    - name: Build with Extended Fluidd + AFC firmware (experimental)
+      run: ./dev.sh make build PROFILE=extended-afc OUTPUT_FILE=U1_extended-afc_${{ env.GIT_VERSION }}_upgrade.bin
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: extended-afc-build
+        path: U1_extended-afc_*_upgrade.bin
+
     - name: Save PR info
       if: github.event_name == 'pull_request'
       run: |
@@ -118,6 +126,7 @@ jobs:
         echo "${{ env.JOB_START }}" > pr-info/job_start
         echo "$(date +%s)" > pr-info/job_end
         echo extended-build >> pr-info/artifacts
+        echo extended-afc-build >> pr-info/artifacts
 
     - name: Upload PR info
       if: github.event_name == 'pull_request'

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,6 +95,8 @@ Overlays are organized into categories based on their scope and build mods. Each
   - e.g. `./dev.sh make build PROFILE=extended-devel`
 - `extended-qemu` - Add the `qemu` mod overlays from `overlays/mods/qemu/` (eth0 hotplug and virtio-touch hwdb mapping for the QEMU dev environment)
   - e.g. `./dev.sh make build PROFILE=extended-qemu`
+- `extended-afc` - **Experimental.** Add the `afc` mod overlays from `overlays/mods/afc/`, integrating the full [AFC-Klipper-Add-On](https://github.com/AFCProject/AFC-Klipper-Add-On) for physical AFC hardware (hubs, buffers, lane control) over CAN bus. See [Experimental AFC Mod](#experimental-afc-mod) below.
+  - e.g. `./dev.sh make build PROFILE=extended-afc`
 
 ### Devel Mod Features
 
@@ -120,6 +122,32 @@ Other entware-ctrl commands:
 - `entware-ctrl nuke` - Remove Entware installation completely
 
 Once initialized, use `opkg` to install packages from the Entware repository.
+
+### Experimental AFC Mod
+
+> **Experimental**: The `afc` mod is not maintained by this project (see
+> [Mods](mods.md#rules)) and may break or be removed at any point without
+> notice. It does not ship in public releases — it is only available as a
+> `develop`-channel CI build artifact or via a local build from source.
+
+Unlike the [AFC-Lite Stub](afc-lite.md), which is a status-reporting-only
+compatibility shim included in the regular `extended` build, the `afc` mod
+adds the **real** [AFC-Klipper-Add-On](https://github.com/AFCProject/AFC-Klipper-Add-On)
+for people with actual AFC hardware (hubs, buffers, lane control) connected
+over CAN bus. It:
+
+- Clones `AFC-Klipper-Add-On` from upstream at build time into
+  `/home/lava/AFC-Klipper-Add-On`.
+- Adds udev rules bringing up the onboard CAN bus chip at 1 Mbps so external
+  AFC MCUs can be reached — see
+  [`overlays/mods/afc/docs/canbus.md`](https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/blob/develop/overlays/mods/afc/docs/canbus.md)
+  for wiring and MCU flashing instructions.
+- Patches Moonraker's gcode metadata parser and Klipper's extruder handling
+  for compatibility with AFC's virtual lane extruders.
+- Exposes an **Enable AFC-Klipper-Add-On Plugin** toggle under
+  **Snapmaker Components** in Fluidd/Mainsail firmware config, which runs
+  AFC-Klipper-Add-On's own installer to wire it into Klipper. It is disabled
+  by default even on `extended-afc` builds.
 
 ### Directory Structure
 


### PR DESCRIPTION
## Problem

The \`afc\` mod (\`overlays/mods/afc/\`) has existed since #615, integrating
the full [AFC-Klipper-Add-On](https://github.com/AFCProject/AFC-Klipper-Add-On)
for physical AFC hardware. \`PROFILE=extended-afc\` already resolved
correctly via the existing mod mechanism, but it was undocumented and never
built by CI, so there was no easy way to get a build to try it.

## Change

- \`pull_request.yaml\` (the \`develop\`-push/PR workflow) now also builds
  \`PROFILE=extended-afc\` and uploads it as a separate
  \`extended-afc-build\` artifact, alongside the regular \`extended\` build.
  \`pre_release.yaml\` is untouched, so this variant never ships in a public
  release — it's only reachable as a \`develop\`/PR CI artifact or a local
  build from source.
- \`development.md\` documents \`extended-afc\` as a Build Option and adds an
  "Experimental AFC Mod" section explaining what it adds (AFC-Klipper-Add-On
  cloned at build time, CAN bus udev rules, Moonraker/Klipper compatibility
  patches, opt-in Fluidd/Mainsail toggle) and how it differs from the
  status-only \`AFC-Lite\` stub already in \`extended\`. Marked experimental
  and unmaintained-by-project, consistent with the \`afc\` mod's existing
  status under [Mods](mods.md#rules).
