### PR TITLE
Split `FULLVERSION` into `BASE_VERSION` and `FULLVERSION`

### DIFF
--- a/docs/functions/api/device/firmware/latest.js
+++ b/docs/functions/api/device/firmware/latest.js
@@ -89,13 +89,6 @@ export async function onRequestGet(context) {
 
   let newVersion = (release.name || release.tag_name).replace(/^(?:Rolling:\s*)?v/, "");
 
-  // HACK:
-  // The device already reported it's running this exact build (its
-  // `BUILD_VERSION` is `<newVersion>-<git abbrev>`, so match on the
-  // `newVersion` prefix) — nothing to offer, so respond the way stock
-  // Snapmaker's API does when there's no pending update.
-  const isCurrentVersion = buildVersion && (buildVersion === newVersion || buildVersion.startsWith(`${newVersion}-`));
-
   const body = {
     code: 200,
     msg: "success",
@@ -105,9 +98,7 @@ export async function onRequestGet(context) {
       note: descAsset.browser_download_url,
       url: binAsset.browser_download_url,
       status: 200,
-      // If the device is already running this exact build, report the version it's running
-      // (so it doesn't try to "upgrade" to the same build again) — otherwise report the new version.
-      version: isCurrentVersion && fullversion ? fullversion : newVersion,
+      version: newVersion,
       createDate: toApiTimestamp(release.created_at),
       modifiedDate: toApiTimestamp(release.published_at || release.created_at),
     },

--- a/overlays/common/01-store-version/scripts/01_store_version.sh
+++ b/overlays/common/01-store-version/scripts/01_store_version.sh
@@ -10,15 +10,20 @@ fi
 
 ABBRV=$(git describe --abbrev --always)
 
+mv "$ROOTFS_DIR/etc/FULLVERSION" "$ROOTFS_DIR/etc/BASE_VERSION"
+
 if [[ "$GIT_VERSION" == *"-$ABBRV" ]]; then
   # 0.9.0-paxx12-1-gabcdef0
+  echo "${GIT_VERSION#v}" > "$ROOTFS_DIR/etc/FULLVERSION"
   echo "${GIT_VERSION#v}" > "$ROOTFS_DIR/etc/BUILD_VERSION"
 elif [[ -n "$GIT_VERSION" ]]; then
   # 0.9.0-paxx12-1-gabcdef0
+  echo "${GIT_VERSION#v}" > "$ROOTFS_DIR/etc/FULLVERSION"
   echo "${GIT_VERSION#v}-${ABBRV}" > "$ROOTFS_DIR/etc/BUILD_VERSION"
 else
   # <git-branch-name>-<abbr>
   GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  echo "${GIT_BRANCH}" > "$ROOTFS_DIR/etc/FULLVERSION"
   echo "${GIT_BRANCH}-${ABBRV}" > "$ROOTFS_DIR/etc/BUILD_VERSION"
 fi
 

--- a/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/01_status_system.yaml
+++ b/overlays/firmware-extended/02-firmware-config/root/usr/local/share/firmware-config/functions/01_status_system.yaml
@@ -7,7 +7,7 @@ status:
     title: System Information
     items:
       - label: Base
-        cmd: cat /etc/FULLVERSION
+        cmd: cat /etc/BASE_VERSION
       - label: Version
         cmd: cat /etc/BUILD_VERSION
       - label: Profile


### PR DESCRIPTION
## Summary

- `01_store_version.sh` preserves the pre-build `FULLVERSION` as `BASE_VERSION` before overwriting `FULLVERSION` with the freshly built version, and always writes `FULLVERSION` alongside `BUILD_VERSION`.
- "System Information" > "Base" now reads `BASE_VERSION` instead of `FULLVERSION`.
- With `FULLVERSION` reliably populated, `latest.js` drops the `isCurrentVersion` hack and always reports `newVersion`.