### PR TITLE
Fix SpoolLink persistence and destructive empty RFID reads

### DIFF
--- a/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
+++ b/overlays/firmware-extended/38-feature-spoollink/root/usr/local/share/spoollink/klipper.cfg
@@ -40,3 +40,4 @@ gcode:
         { action_call_remote_method("spoollink_resolve_spool",
             channel=channel, spool_id=spool_id, card_uid=card_uid) }
     {% endif %}
+    


### PR DESCRIPTION
### Summary
Fixes [#722](https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/issues/722).

A manually assigned Spoolman spool was lost when OpenRFID was triggered without finding a readable RFID tag. This happened during:
 
- Read spool tags
- firmware or Klipper restart
- printer power cycles
- filament load and unload operations
- The issue does not occur with Filament Detection: Snapmaker. It affects the OpenRFID path, which uses filament_detect/set.

### Root Cause
OpenRFID sends an empty or metadata-free request when no tag is detected or when a read temporarily fails.

The endpoint currently treats an already official channel as a destructive update:
`self._filament_info_update(channel, filament_info, True)`

The empty filament_info contains no SPOOL_ID. As a result, the existing Spoolman assignment is replaced with 0.

### Fix
Use has_params as the is_clear value:
`self._filament_info_update(channel, filament_info, has_params)`

This preserves the existing filament and Spoolman assignment when OpenRFID sends an empty payload, while  still allowing RFID data to replace the manual spool.

### Expected Behavior

- A manually assigned Spoolman spool remains assigned when no RFID tag is detected.
- OpenRFID read failures and empty reads are non-destructive.
- A real RFID read with filament data can still overwrite the current assignment.
- Spool stil clears on refresh via WebUI
- Snapmaker-native RFID detection behavior is unchanged.

### Validation
Replicated issue [#722](https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/issues/722).
Manual spool assignment persists after restart with the change

ToDo
Test RFID Reads and general beahviour with RFID Filament 